### PR TITLE
Add AsyncFd::cancel_previous and cancel_all

### DIFF
--- a/src/op.rs
+++ b/src/op.rs
@@ -228,6 +228,17 @@ impl Submission {
         };
     }
 
+    /// Attempt to cancel an already issued request.
+    ///
+    /// Avaialable since Linux kernel 5.5.
+    pub(crate) unsafe fn cancel(&mut self, fd: RawFd, flags: u32) {
+        self.inner.opcode = OperationCode::AsyncCancel as u8;
+        self.inner.fd = fd;
+        self.inner.__bindgen_anon_3 = libc::io_uring_sqe__bindgen_ty_3 {
+            cancel_flags: flags | libc::IORING_ASYNC_CANCEL_FD,
+        };
+    }
+
     /// Open a file by `pathname` in directory `dir_fd`.
     pub(crate) unsafe fn open_at(
         &mut self,

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,0 +1,107 @@
+//! Tests for the I/O operations.
+
+#![feature(once_cell)]
+
+use std::io;
+
+mod util;
+use util::{bind_ipv4, expect_io_errno, expect_io_error_kind, tcp_ipv4_socket, test_queue, Waker};
+
+#[test]
+fn cancel_previous_accept() {
+    let sq = test_queue();
+    let waker = Waker::new();
+
+    let listener = waker.block_on(tcp_ipv4_socket(sq));
+    bind_ipv4(&listener);
+
+    let accept = listener.accept().unwrap();
+
+    waker
+        .block_on(listener.cancel_previous().unwrap())
+        .expect("failed to cancel accept call");
+
+    expect_io_errno(waker.block_on(accept), libc::ECANCELED);
+}
+
+#[test]
+fn cancel_all_accept() {
+    let sq = test_queue();
+    let waker = Waker::new();
+
+    let listener = waker.block_on(tcp_ipv4_socket(sq));
+    bind_ipv4(&listener);
+
+    let accept = listener.accept().unwrap();
+
+    waker
+        .block_on(listener.cancel_all().unwrap())
+        .expect("failed to cancel all calls");
+
+    expect_io_errno(waker.block_on(accept), libc::ECANCELED);
+}
+
+#[test]
+fn cancel_previous_accept_twice() {
+    let sq = test_queue();
+    let waker = Waker::new();
+
+    let listener = waker.block_on(tcp_ipv4_socket(sq));
+    bind_ipv4(&listener);
+
+    let accept = listener.accept().unwrap();
+
+    waker
+        .block_on(listener.cancel_previous().unwrap())
+        .expect("failed to cancel accept call");
+    // And again.
+    expect_io_error_kind(
+        waker.block_on(listener.cancel_previous().unwrap()),
+        io::ErrorKind::NotFound,
+    );
+
+    expect_io_errno(waker.block_on(accept), libc::ECANCELED);
+}
+
+#[test]
+fn cancel_all_accept_twice() {
+    let sq = test_queue();
+    let waker = Waker::new();
+
+    let listener = waker.block_on(tcp_ipv4_socket(sq));
+    bind_ipv4(&listener);
+
+    let accept = listener.accept().unwrap();
+
+    waker
+        .block_on(listener.cancel_all().unwrap())
+        .expect("failed to cancel all calls");
+    // And again. Unlike `cancel_previous`, this should return ok.
+    waker
+        .block_on(listener.cancel_all().unwrap())
+        .expect("failed to cancel all calls");
+
+    expect_io_errno(waker.block_on(accept), libc::ECANCELED);
+}
+
+#[test]
+fn cancel_previous_no_operation_in_progress() {
+    let sq = test_queue();
+    let waker = Waker::new();
+
+    let socket = waker.block_on(tcp_ipv4_socket(sq));
+
+    let cancel = socket.cancel_previous().unwrap();
+    expect_io_error_kind(waker.block_on(cancel), io::ErrorKind::NotFound);
+}
+
+#[test]
+fn cancel_all_no_operation_in_progress() {
+    let sq = test_queue();
+    let waker = Waker::new();
+
+    let socket = waker.block_on(tcp_ipv4_socket(sq));
+
+    let cancel = socket.cancel_all().unwrap();
+    waker.block_on(cancel).expect("failed to cancel");
+}


### PR DESCRIPTION
Cancels the previous or all previous scheduled operations.

Closes #3.