### PR TITLE
Fix race condition in writing to submission array

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -182,10 +182,8 @@ fn mmap_submission_queue(
                 queued_ops,
                 blocked_futures: Mutex::new(Vec::new()),
                 pending_tail: AtomicU32::new(0),
-                pending_index: AtomicU32::new(0),
                 // Fields are shared with the kernel.
                 kernel_read: submission_queue.add(parameters.sq_off.head as usize).cast(),
-                tail: submission_queue.add(parameters.sq_off.tail as usize).cast(),
                 /* NOTE: unused because we expect `IORING_FEAT_NODROP`.
                 dropped: submission_queue
                     .add(parameters.sq_off.dropped as usize)
@@ -195,9 +193,11 @@ fn mmap_submission_queue(
                     .add(parameters.sq_off.flags as usize)
                     .cast(),
                 entries: submission_queue_entries.cast(),
+                array_index: Mutex::new(0),
                 array: submission_queue
                     .add(parameters.sq_off.array as usize)
                     .cast(),
+                array_tail: submission_queue.add(parameters.sq_off.tail as usize).cast(),
             }),
         })
     }


### PR DESCRIPTION
Consider the following execution.

```
Thread A                           | Thread B
...                                | ...
...                                | Got `array_index` 0.
Got `array_index` 1.               |
Writes index to `shared.array[1]`. |
`shared.tail.fetch_add` to 1.      |
At this point the kernel will/can read `shared.array[0]`, but
thread B hasn't filled it yet. So the kernel will read an invalid
index!
                                   | Writes index to `shared.array[0]`.
                                   | `shared.tail.fetch_add` to 2.
```

That's bad.

This commit fixes the problem by replacing the AtomicU32 with a Mutex<u32>, which will protect the array access in addition of getting index from it.

Fixes #2.