### PR TITLE
Replace drop_task_waker with IntoDropWaker trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -555,7 +555,7 @@ impl SubmissionQueue {
                 // We achieve 1 by creating a special waker that just drops the
                 // resources in `resources`.
                 // SAFETY: we're not going to clone the `waker`.
-                let waker = unsafe { drop_task_waker(resources) };
+                let waker = unsafe { Box::from(resources).into_waker() };
                 // We achive 2 by setting the operation state to dropped, so
                 // that `QueuedOperation::set_result` returns true, which makes
                 // `complete` below make the queued operation slot available
@@ -643,30 +643,70 @@ impl SubmissionQueue {
     }
 }
 
-/// Returns a `task::Waker` that will drop `to_drop` when the waker is dropped.
+/// Trait that turns a value into a [`task::Waker`] that will drop itself when
+/// the waker is dropped.
 ///
 /// # Safety
 ///
 /// The returned `task::Waker` cannot be cloned, it will panic.
-pub(crate) unsafe fn drop_task_waker<T>(to_drop: T) -> task::Waker {
-    // SAFETY: this is safe because we just passed the pointer created by
-    // `Box::into_raw` to this function.
-    fn drop_by_ptr<T>(ptr: *const ()) {
-        unsafe { drop(Box::<T>::from_raw(ptr as _)) }
-    }
+trait IntoDropWaker {
+    unsafe fn into_waker(self) -> task::Waker;
+}
 
-    // SAFETY: we meet the `task::Waker` and `task::RawWaker` requirements.
-    unsafe {
-        task::Waker::from_raw(task::RawWaker::new(
-            Box::into_raw(Box::from(to_drop)) as _,
-            &task::RawWakerVTable::new(
-                |_| panic!("attempted to clone `a10::drop_task_waker`"),
-                // SAFETY: `wake` takes ownership, so dropping is safe.
-                drop_by_ptr::<T>,
-                |_| { /* `wake_by_ref` is a no-op. */ },
-                drop_by_ptr::<T>,
-            ),
-        ))
+/* TODO: enable this once the specialization feature is closer to stabalisation,
+ * see <https://github.com/rust-lang/rust/issues/31844>.
+default impl<T> IntoDropWaker for T {
+    unsafe fn into_waker(self) -> task::Waker {
+        Box::from(self).into_waker()
+    }
+}
+*/
+
+impl<T> IntoDropWaker for Box<T> {
+    unsafe fn into_waker(self) -> task::Waker {
+        // SAFETY: this is safe because we just passed the pointer created by
+        // `Box::into_raw` to this function.
+        unsafe fn drop_by_ptr<T>(ptr: *const ()) {
+            drop(Box::<T>::from_raw(ptr as _))
+        }
+
+        // SAFETY: we meet the `task::Waker` and `task::RawWaker` requirements.
+        unsafe {
+            task::Waker::from_raw(task::RawWaker::new(
+                Box::into_raw(self) as _,
+                &task::RawWakerVTable::new(
+                    |_| panic!("attempted to clone `a10::drop_task_waker`"),
+                    // SAFETY: `wake` takes ownership, so dropping is safe.
+                    drop_by_ptr::<T>,
+                    |_| { /* `wake_by_ref` is a no-op. */ },
+                    drop_by_ptr::<T>,
+                ),
+            ))
+        }
+    }
+}
+
+impl<T> IntoDropWaker for Arc<T> {
+    unsafe fn into_waker(self) -> task::Waker {
+        // SAFETY: this is safe because we just passed the pointer created by
+        // `Arc::into_raw` to this function.
+        unsafe fn drop_by_ptr<T>(ptr: *const ()) {
+            drop(Arc::<T>::from_raw(ptr as _))
+        }
+
+        // SAFETY: we meet the `task::Waker` and `task::RawWaker` requirements.
+        unsafe {
+            task::Waker::from_raw(task::RawWaker::new(
+                Arc::into_raw(self) as _,
+                &task::RawWakerVTable::new(
+                    |_| panic!("attempted to clone `a10::drop_task_waker`"),
+                    // SAFETY: `wake` takes ownership, so dropping is safe.
+                    drop_by_ptr::<T>,
+                    |_| { /* `wake_by_ref` is a no-op. */ },
+                    drop_by_ptr::<T>,
+                ),
+            ))
+        }
     }
 }
 
@@ -918,7 +958,7 @@ impl Drop for AsyncFd {
     }
 }
 
-/// Waker allow waking of [`Ring`].
+/// Waker allows waking of [`Ring`].
 ///
 /// All this does is interrupt a call to [`Ring::poll`].
 #[derive(Clone)]


### PR DESCRIPTION
Currently this does more or less the same thing, but the in future, once the specialization feature is usable, we can implement the trait for other types, falling back to making the allocation only when needed.