### PR TITLE
Add AsyncFd::multishot_accept 

### DIFF
--- a/src/op.rs
+++ b/src/op.rs
@@ -370,6 +370,15 @@ impl Submission {
         };
     }
 
+    pub(crate) unsafe fn multishot_accept(&mut self, fd: RawFd, flags: libc::c_int) {
+        self.inner.opcode = libc::IORING_OP_ACCEPT as u8;
+        self.inner.fd = fd;
+        self.inner.__bindgen_anon_3 = libc::io_uring_sqe__bindgen_ty_3 {
+            accept_flags: flags as _,
+        };
+        self.inner.ioprio = libc::IORING_ACCEPT_MULTISHOT as _;
+    }
+
     /// Attempt to cancel an already issued request.
     ///
     /// Avaialable since Linux kernel 5.5.

--- a/tests/async_fd.rs
+++ b/tests/async_fd.rs
@@ -1,6 +1,6 @@
 //! Tests for [`a10::AsyncFd`].
 
-#![feature(once_cell)]
+#![feature(async_iterator, once_cell)]
 
 mod util;
 

--- a/tests/ring.rs
+++ b/tests/ring.rs
@@ -1,6 +1,6 @@
 //! Tests for [`a10::Ring`].
 
-#![feature(once_cell)]
+#![feature(async_iterator, once_cell)]
 
 use std::pin::Pin;
 use std::task::Poll;

--- a/tests/signals.rs
+++ b/tests/signals.rs
@@ -1,4 +1,4 @@
-#![feature(once_cell)]
+#![feature(async_iterator, once_cell)]
 
 use std::mem::MaybeUninit;
 use std::pin::Pin;


### PR DESCRIPTION
  Support multishot operations in QueuedOperation

    This removes some complexity from the type and Ring::poll and the
    functions it has to call to process a completion event. Instead of
    partially handling the event in Ring::poll and QueuedOperation's method
    we now do it all in a single function: QueuedOperation::update. This
    removes the OperationResult enum entirely and replaces it with
    QueuedOperationKind and some boolean fields on QueuedOperation.

    The QueuedOperationKind enum is required to support multishot
    operations, which can result in multiple operation results before the
    user has a chance to read them.

    The downside of support multishot operations is the growth in the size
    of QueuedOperation from 24 to 56 bytes. Most of this comes from the
    added Vec (24 bytes), the QueuedOperationKind enum tag (8 bytes) and
    the additional booleans (8 bytes).

    We could reduce the size QueuedOperationKind using something like a
    ThinVec which holds its capacity and length in the heap allocation
    instead of the stack. Something to consider in the future.

commit 28e9c5e9ee2b47f98d20947678661038f635d8bb
Author: Thomas de Zeeuw <thomasdezeeuw@gmail.com>
Date:   Wed Feb 15 21:29:38 2023 +0000

    Add op_async_iter! macro

    Macro to create an operation AsyncIterator structure.

    Has a bug as it doesn't cancel the multishot operation when the Future
    is dropped.

commit a428f356bab34ebafdd706dc601ca0d296d851d4
Author: Thomas de Zeeuw <thomasdezeeuw@gmail.com>
Date:   Wed Feb 15 22:21:06 2023 +0000

    Add AsyncFd::multishot_accept

    Returns an AsyncIterator of accepted TCP streams.