### PR TITLE
Rework SocketAddress trait

### DIFF
--- a/src/op.rs
+++ b/src/op.rs
@@ -304,7 +304,7 @@ impl Submission {
     pub(crate) unsafe fn connect(
         &mut self,
         fd: RawFd,
-        address: *mut libc::sockaddr,
+        address: *const libc::sockaddr,
         address_length: libc::socklen_t,
     ) {
         self.inner.opcode = libc::IORING_OP_CONNECT as u8;


### PR DESCRIPTION
This changes the SocketAddress trait to change from a single to three methods.

One method, cast_ptr, is be used by connect and sendto to get a raw pointer and length from the address. It did this previously using cast_ptr, but that was more error prone.

The other two methods, as_mut_ptr and init, are used by accept to first get a mutable raw pointer to the address and to initialise the address respectively.

Finally it changes which types implement SocketAddress. Previously the dynamically sized types, sockaddr, sockaddr_storage and sockaddr_un, implemented SocketAddress. However the weren't actually usable as without the length you don't know how many bytes of the address is usable. In other words they didn't work for the connect call, which incorrectly used the entire address storage previously.

For address of a dynamic size, e.g. sockaddr_un and sockaddr_storage, it needs to know the length of the address to be useful. For other address types, mainly the IP address sockaddr_in and sockaddr_in6, we don't need this information.

This also changes the return value of accept to not return the socklen_t any more as that is not internal to address A (where useful).