### PR TITLE
Use OwnedFd in AsyncFd

### DIFF
--- a/src/cancel.rs
+++ b/src/cancel.rs
@@ -45,7 +45,7 @@ op_future! {
     },
     setup_state: flags: u32,
     setup: |submission, fd, (), flags| unsafe {
-        submission.cancel(fd.fd, flags);
+        submission.cancel(fd.fd(), flags);
     },
     map_result: |n| {
         #[allow(clippy::cast_sign_loss)] // Negative values are mapped to errors.

--- a/tests/async_fd/io.rs
+++ b/tests/async_fd/io.rs
@@ -880,7 +880,7 @@ fn pipe2(sq: SubmissionQueue) -> io::Result<(AsyncFd, AsyncFd)> {
     }
 
     // SAFETY: we just initialised the `fds` above.
-    let r = unsafe { AsyncFd::new(fds[0], sq.clone()) };
-    let w = unsafe { AsyncFd::new(fds[1], sq) };
+    let r = unsafe { AsyncFd::from_raw_fd(fds[0], sq.clone()) };
+    let w = unsafe { AsyncFd::from_raw_fd(fds[1], sq) };
     Ok((r, w))
 }


### PR DESCRIPTION
Changes AsyncFd::new to accept a OwnedFd instead of a RawFd.

Adds Async::from_raw_fd to create an AsyncFd from a RawFd.

The io::std{out,err,in} functions are now longer constant as
AsyncFd::from_raw_fd can't be constant.