### PR TITLE
Add with_kernel_thread option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,7 +639,7 @@ impl SubmissionQueue {
         // outdated.
         let kernel_read = unsafe { (*self.shared.kernel_read).load(Ordering::Relaxed) };
         let pending_tail = self.shared.pending_tail.load(Ordering::Relaxed);
-        (pending_tail - kernel_read) as usize
+        (self.shared.len - (pending_tail - kernel_read)) as usize
     }
 
     /// Wake up the kernel thread polling for submission events, if the kernel


### PR DESCRIPTION
Allows enabling or disabling of starting a kernel thread to poll the
submission queue.