### PR TITLE
Don't leak SubmissionQueues in Std{in,out,err}

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -65,6 +65,17 @@ macro_rules! stdio {
                 &self.0
             }
         }
+
+        impl std::ops::Drop for $name {
+            fn drop(&mut self) {
+                // We don't want to close the file descriptor, but we do need to
+                // drop our reference to the submission queue.
+                // SAFETY: with `ManuallyDrop` we don't drop the `AsyncFd` so
+                // it's not dropped twice. Otherwise we get access to it using
+                // safe methods.
+                unsafe { std::ptr::drop_in_place(&mut self.0.sq) };
+            }
+        }
     };
 }
 


### PR DESCRIPTION
The types wrapped the AsyncFd in ManuallyDrop which means that the file descriptor is never closed, which is good. But it also means that the SubmissionQueue was never dropped, which is bad. So manually drop the SubmissionQueue in Drop implementation.