### PR TITLE
Lower CI timeout to 5 minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   Test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
@@ -24,7 +24,7 @@ jobs:
       run: cargo test --release
   Nightly:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@nightly
@@ -38,7 +38,7 @@ jobs:
       run: cargo test --features nightly --release
   Clippy:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@nightly
@@ -48,7 +48,7 @@ jobs:
       run: make clippy
   Docs:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@nightly
@@ -56,7 +56,7 @@ jobs:
       run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
   Rustfmt:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
@@ -66,7 +66,7 @@ jobs:
       run: cargo fmt --all -- --check
   Sanitizer:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     if: false
     strategy:
       fail-fast: false

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ dev:
 
 test:
 	cargo test -- --quiet
+	cargo test --all-features -- --quiet
 
 test_sanitizers:
 	$(MAKE) test_sanitizer sanitizer=address


### PR DESCRIPTION
Normally they run in less than 2 minutes, so 5 should be plenty.