### PR TITLE
Better cancelation for dropping incomplete Futures

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -764,9 +764,21 @@ impl Future for Extractor<CreateDir> {
 
 impl Drop for CreateDir {
     fn drop(&mut self) {
-        if let OpState::Running(op_index) = self.state {
-            let path = self.path.take().unwrap();
-            self.sq.drop_op(op_index, path);
+        if let Some(path) = self.path.take() {
+            match self.state {
+                OpState::Running(op_index) => {
+                    let result = self.sq.cancel_op(op_index, path, |submission| unsafe {
+                        submission.cancel_op(op_index);
+                        // We'll get a canceled completion event if we succeeded, which
+                        // is sufficient to cleanup the operation.
+                        submission.no_completion_event();
+                    });
+                    if let Err(err) = result {
+                        log::error!("dropped a10::CreateDir before completion, attempt to cancel failed: {err}");
+                    }
+                }
+                OpState::NotStarted(_) | OpState::Done => drop(path),
+            }
         }
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -777,7 +777,7 @@ impl Drop for CreateDir {
                         log::error!("dropped a10::CreateDir before completion, attempt to cancel failed: {err}");
                     }
                 }
-                OpState::NotStarted(_) | OpState::Done => drop(path),
+                OpState::NotStarted(()) | OpState::Done => drop(path),
             }
         }
     }
@@ -874,7 +874,7 @@ impl Drop for Rename {
                         log::error!("dropped a10::CreateDir before completion, attempt to cancel failed: {err}");
                     }
                 }
-                OpState::NotStarted(_) | OpState::Done => {
+                OpState::NotStarted(()) | OpState::Done => {
                     drop(from);
                     drop(to);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,6 +508,7 @@ impl SubmissionQueue {
     pub fn try_send_msg(&self, token: MsgToken, data: u32) -> io::Result<()> {
         self.add_no_result(|submission| unsafe {
             submission.msg(self.shared.ring_fd.as_raw_fd(), (token.0).0 as u64, data, 0);
+            submission.no_completion_event();
         })?;
         Ok(())
     }

--- a/src/op.rs
+++ b/src/op.rs
@@ -1196,7 +1196,11 @@ impl<S> OpState<S> {
         match self {
             OpState::NotStarted(_) => CancelResult::NotStarted,
             OpState::Running(op_index) => {
-                match sq.add_no_result(|submission| unsafe { submission.cancel_op(*op_index) }) {
+                let result = sq.add_no_result(|submission| unsafe {
+                    submission.cancel_op(*op_index);
+                    submission.no_completion_event();
+                });
+                match result {
                     Ok(()) => CancelResult::Canceled,
                     Err(QueueFull(())) => CancelResult::QueueFull,
                 }

--- a/src/op.rs
+++ b/src/op.rs
@@ -1426,7 +1426,7 @@ macro_rules! op_async_iter {
                         std::result::Result::Ok(()) => {},
                         // Failed to cancel, this will lead to fd leaks.
                         std::result::Result::Err(err) => {
-                            log::error!(concat!("dropped ", stringify!($name), " before canceling it, attempt to cancel failed, will leak file descriptors: {}"), err);
+                            log::error!(concat!("dropped a10::", stringify!($name), " before canceling it, attempt to cancel failed: {}"), err);
                         }
                     }
                     self.fd.sq.drop_op(op_index, ());

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -84,7 +84,9 @@ impl<'a> Drop for OneshotPoll<'a> {
                 submission.no_completion_event();
             });
             if let Err(err) = result {
-                log::error!("error submitting poll removal operation for a10::OneshotPoll: {err}");
+                log::error!(
+                    "dropped a10::OneshotPoll before canceling it, attempt to cancel failed: {err}"
+                );
             }
         }
     }
@@ -190,7 +192,7 @@ impl<'a> Drop for MultishotPoll<'a> {
             });
             if let Err(err) = result {
                 log::error!(
-                    "error submitting poll removal operation for a10::MultishotPoll: {err}"
+                    "dropped a10::MultishotPoll before canceling it, attempt to cancel failed: {err}"
                 );
             }
         }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -85,7 +85,7 @@ impl<'a> Drop for OneshotPoll<'a> {
             });
             if let Err(err) = result {
                 log::error!(
-                    "dropped a10::OneshotPoll before canceling it, attempt to cancel failed: {err}"
+                    "dropped a10::OneshotPoll before completion, attempt to cancel failed: {err}"
                 );
             }
         }

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -322,7 +322,9 @@ impl Drop for ReceiveSignals {
                     submission.no_completion_event();
                 });
             if let Err(err) = result {
-                log::error!("error submitting cancel operation for a10::ReceiveSignals: {err}");
+                log::error!(
+                    "dropped a10::ReceiveSignals before canceling it, attempt to cancel failed: {err}"
+                );
             }
         }
     }


### PR DESCRIPTION
Instead of delaying the drop of resources, using `SubmissionQueue::drop_op`, we now actively attempt to cancel the operation using `cancel_op` (in addition to delaying the deallocation).

Improves the situation for #10 (somewhat).