### PR TITLE
Add process:wait(_on)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ clippy:
 		--allow clippy::use-self \
 		\
 		--allow clippy::cast-possible-truncation \
+		--allow clippy::cast-possible-wrap \
 
 doc:
 	cargo doc

--- a/src/cancel.rs
+++ b/src/cancel.rs
@@ -164,7 +164,7 @@ impl<'fd> Future for CancelOp<'fd> {
             Poll::Ready(result) => {
                 self.state = OpState::Done;
                 match result {
-                    Ok((_, res)) => Poll::Ready(Ok(debug_assert!(res == 0))),
+                    Ok((_, _)) => Poll::Ready(Ok(())),
                     Err(err) => Poll::Ready(Err(err)),
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@ pub mod msg;
 pub mod net;
 mod op;
 pub mod poll;
+pub mod process;
 pub mod signals;
 
 // TODO: replace this with definitions from the `libc` crate once available.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -867,7 +867,7 @@ impl SubmissionQueue {
     where
         F: FnOnce(&mut Submission),
     {
-        log::trace!(op_index = op_index.0; "canceling operation as receiver (Future) was dropped before completion");
+        log::trace!(op_index = op_index.0; "canceling operation");
         if let Some(operation) = self.shared.queued_ops.get(op_index.0) {
             let mut operation = operation.lock().unwrap();
             if let Some(op) = &mut *operation {

--- a/src/op.rs
+++ b/src/op.rs
@@ -666,6 +666,7 @@ impl Submission {
         };
     }
 
+    #[allow(clippy::cast_possible_wrap)]
     pub(crate) unsafe fn waitid(
         &mut self,
         id: libc::id_t,

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,128 @@
+//! Process handling.
+
+use std::future::Future;
+use std::io;
+use std::mem::MaybeUninit;
+use std::pin::Pin;
+use std::process::Child;
+use std::task::{self, Poll};
+
+use crate::cancel::{Cancel, CancelOp, CancelResult};
+use crate::op::{poll_state, OpState};
+use crate::SubmissionQueue;
+
+/// Wait on the child `process`.
+///
+/// See [`wait`].
+pub fn wait_on(sq: SubmissionQueue, process: &Child, options: libc::c_int) -> WaitId {
+    wait(sq, WaitOn::Process(process.id()), options)
+}
+
+/// Obtain status information on termination, stop, and/or continue events in
+/// one of the caller's child processes.
+///
+/// Also see [`wait_on`] to wait on a [`Child`] process.
+#[doc(alias = "waitid")]
+pub fn wait(sq: SubmissionQueue, wait: WaitOn, options: libc::c_int) -> WaitId {
+    WaitId {
+        sq,
+        state: OpState::NotStarted((wait, options)),
+        info: Some(Box::new(MaybeUninit::uninit())),
+    }
+}
+
+/// Defines on what process (or processes) to wait.
+#[doc(alias = "idtype")]
+#[doc(alias = "idtype_t")]
+#[derive(Copy, Clone, Debug)]
+pub enum WaitOn {
+    /// Wait for the child process.
+    #[doc(alias = "P_PID")]
+    Process(libc::id_t),
+    /// Wait for any child process in the process group with ID.
+    #[doc(alias = "P_PGID")]
+    Group(libc::id_t),
+    /// Wait for all childeren.
+    #[doc(alias = "P_ALL")]
+    All,
+}
+
+/// [`Future`] behind [`wait`].
+#[derive(Debug)]
+#[must_use = "`Future`s do nothing unless polled"]
+pub struct WaitId {
+    sq: SubmissionQueue,
+    /// Buffer to write into, needs to stay in memory so the kernel can
+    /// access it safely.
+    info: Option<Box<MaybeUninit<libc::signalfd_siginfo>>>,
+    state: OpState<(WaitOn, libc::c_int)>,
+}
+
+impl Future for WaitId {
+    type Output = io::Result<Box<libc::siginfo_t>>;
+
+    fn poll(mut self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        let op_index = poll_state!(
+            WaitId,
+            self.state,
+            self.sq,
+            ctx,
+            |submission, (wait, options)| unsafe {
+                let (id_type, pid) = match wait {
+                    WaitOn::Process(pid) => (libc::P_PID, pid),
+                    WaitOn::Group(pid) => (libc::P_PGID, pid),
+                    WaitOn::All => (libc::P_ALL, 0), // NOTE: id is ignored.
+                };
+                let info = self.info.as_ref().unwrap().as_ptr().cast_mut();
+                submission.waitid(pid, id_type, options, info);
+            }
+        );
+
+        match self.sq.poll_op(ctx, op_index) {
+            Poll::Ready(result) => {
+                self.state = OpState::Done;
+                match result {
+                    Ok((_, _)) => Poll::Ready(Ok(unsafe {
+                        Box::from_raw(Box::into_raw(self.info.take().unwrap()).cast())
+                    })),
+                    Err(err) => Poll::Ready(Err(err)),
+                }
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Cancel for WaitId {
+    fn try_cancel(&mut self) -> CancelResult {
+        self.state.try_cancel(&self.sq)
+    }
+
+    fn cancel(&mut self) -> CancelOp {
+        self.state.cancel(&self.sq)
+    }
+}
+
+impl Drop for WaitId {
+    fn drop(&mut self) {
+        if let Some(info) = self.info.take() {
+            match self.state {
+                OpState::Running(op_index) => {
+                    // Only drop the signal `info` field once we know the
+                    // operation has finished, otherwise the kernel might write
+                    // into memory we have deallocated.
+                    let result = self.sq.cancel_op(op_index, info, |submission| unsafe {
+                        submission.cancel_op(op_index);
+                        // We'll get a canceled completion event if we succeeded, which
+                        // is sufficient to cleanup the operation.
+                        submission.no_completion_event();
+                    });
+                    if let Err(err) = result {
+                        log::error!("dropped a10::WaitId before canceling it, attempt to cancel failed: {err}");
+                    }
+                }
+                OpState::NotStarted((_, _)) | OpState::Done => drop(info),
+            }
+        }
+    }
+}

--- a/tests/ring.rs
+++ b/tests/ring.rs
@@ -374,6 +374,7 @@ fn madvise() {
 
 #[test]
 fn process_wait_on() {
+    require_kernel!(6, 7);
     let sq = test_queue();
     let waker = Waker::new();
 
@@ -398,6 +399,7 @@ fn process_wait_on() {
 
 #[test]
 fn process_wait_on_cancel() {
+    require_kernel!(6, 7);
     let sq = test_queue();
     let waker = Waker::new();
 
@@ -417,6 +419,7 @@ fn process_wait_on_cancel() {
 
 #[test]
 fn process_wait_on_drop_before_complete() {
+    require_kernel!(6, 7);
     let sq = test_queue();
 
     let process = Command::new("sleep").arg("1000").spawn().unwrap();


### PR DESCRIPTION
Wraps the waitid(2) system call/io_uring operation.

This adds a new process module to hold the functions and related types.