### PR TITLE
Add Config::disable and Ring::enable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -151,6 +151,7 @@ impl<'r> Config<'r> {
     }
 
     /// Same as [`Config::attach`], but accepts a [`SubmissionQueue`].
+    #[doc(alias = "IORING_SETUP_ATTACH_WQ")]
     pub const fn attach_queue(mut self, other_ring: &'r SubmissionQueue) -> Self {
         self.attach = Some(other_ring);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,20 @@ impl Ring {
         &self.sq
     }
 
+    /// Enable the ring.
+    ///
+    /// This only required when starting the ring in disabled mode, see
+    /// [`Config::disable`].
+    pub fn enable(&mut self) -> io::Result<()> {
+        libc::syscall!(io_uring_register(
+            self.sq.shared.ring_fd.as_raw_fd(),
+            libc::IORING_REGISTER_ENABLE_RINGS,
+            ptr::null(),
+            0,
+        ))?;
+        Ok(())
+    }
+
     /// Poll the ring for completions.
     ///
     /// This will wake all completed [`Future`]s with the result of their

--- a/tests/ring.rs
+++ b/tests/ring.rs
@@ -150,6 +150,20 @@ fn submission_queue_full_is_handle_internally() {
 }
 
 #[test]
+fn config_disabled() {
+    init();
+    let mut ring = Ring::config(1).disable().build().unwrap();
+
+    // In a disabled state, so we expect an error.
+    let err = ring.poll(None).unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(libc::EBADFD));
+
+    // Enabling it should allow us to poll.
+    ring.enable().unwrap();
+    ring.poll(Some(Duration::from_millis(1))).unwrap();
+}
+
+#[test]
 fn wake_ring() {
     init();
     let mut ring = Ring::config(2)


### PR DESCRIPTION
Allows the ring to be started in a disable mode, and to be enabled again.