### PR TITLE
Fix flaky cancel tests

### DIFF
--- a/src/cancel.rs
+++ b/src/cancel.rs
@@ -77,7 +77,7 @@ pub trait Cancel {
     /// If the operation was found and canceled this returns `Ok(())`.
     ///
     /// If this is called on an [`AsyncIterator`] it will cause them to return
-    /// `None` (eventuaully, it may still return pending items).
+    /// `None` (eventually, it may still return pending items).
     ///
     /// [`AsyncIterator`]: std::async_iter::AsyncIterator
     fn cancel(&mut self) -> CancelOp;

--- a/src/io/read_buf.rs
+++ b/src/io/read_buf.rs
@@ -467,6 +467,7 @@ impl ReadBuf {
     }
 
     /// Returns the remaining spare capacity of the buffer.
+    #[allow(clippy::needless_pass_by_ref_mut)] // See https://github.com/rust-lang/rust-clippy/issues/12905.
     pub fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<u8>] {
         if let Some(ptr) = self.owned {
             let unused_len = self.shared.buf_size as usize - ptr.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,7 @@ impl Ring {
     ///
     /// This only required when starting the ring in disabled mode, see
     /// [`Config::disable`].
+    #[allow(clippy::needless_pass_by_ref_mut)]
     pub fn enable(&mut self) -> io::Result<()> {
         self.sq
             .register(libc::IORING_REGISTER_ENABLE_RINGS, ptr::null(), 0)
@@ -348,6 +349,7 @@ impl Ring {
     }
 
     /// Wake [`SharedSubmissionQueue::blocked_futures`].
+    #[allow(clippy::needless_pass_by_ref_mut)]
     fn wake_blocked_futures(&mut self) {
         // This not particullary efficient, but with a large enough number of
         // entries, `IORING_SETUP_SQPOLL` and suffcient calls to [`Ring::poll`]

--- a/tests/async_fd/direct.rs
+++ b/tests/async_fd/direct.rs
@@ -27,7 +27,7 @@ fn to_file_descriptor() {
     let waker = Waker::new();
 
     let open_file = OpenOptions::new().open(sq, LOREM_IPSUM_5.path.into());
-    let direct_fd = dbg!(waker.block_on(open_file)).unwrap();
+    let direct_fd = waker.block_on(open_file).unwrap();
     let regular_fd = waker.block_on(direct_fd.to_file_descriptor()).unwrap();
 
     check_fs_fd(waker, regular_fd, direct_fd);

--- a/tests/async_fd/io.rs
+++ b/tests/async_fd/io.rs
@@ -755,19 +755,17 @@ fn cancel_all_twice_accept() {
     let listener = waker.block_on(tcp_ipv4_socket(sq));
     bind_and_listen_ipv4(&listener);
 
-    let mut accept = listener.accept::<libc::sockaddr_in>();
-    // Poll the future to schedule the operation, can't use `start_op` as the
-    // address doesn't implement `fmt::Debug`.
-    assert!(poll_nop(Pin::new(&mut accept)).is_pending());
+    let mut accept = listener.accept::<a10::net::NoAddress>();
+    start_op(&mut accept);
 
     let n = waker
         .block_on(listener.cancel_all())
         .expect("failed to cancel all calls");
-    assert!(n == 1);
+    assert_eq!(n, 1);
     let n2 = waker
         .block_on(listener.cancel_all())
         .expect("failed to cancel all calls");
-    assert!(n2 == 0);
+    assert_eq!(n2, 0);
 
     expect_io_errno(waker.block_on(accept), libc::ECANCELED);
 }

--- a/tests/async_fd/net.rs
+++ b/tests/async_fd/net.rs
@@ -385,13 +385,8 @@ fn connect() {
     client.write_all(DATA2).expect("failed to write");
     buf.clear();
     buf.reserve(DATA2.len() + 1);
-    let mut buf = waker.block_on(stream.read(buf)).expect("failed to read");
+    let buf = waker.block_on(stream.read(buf)).expect("failed to read");
     assert_eq!(buf, DATA2);
-
-    // Dropping the stream should closing it.
-    drop(stream);
-    let n = client.read(&mut buf).expect("failed to read");
-    assert_eq!(n, 0);
 }
 
 #[test]

--- a/tests/ring.rs
+++ b/tests/ring.rs
@@ -279,7 +279,7 @@ fn message_sending() {
 
     let (msg_listener, msg_token) = msg_listener(sq.clone()).unwrap();
     let mut msg_listener = pin!(msg_listener);
-    start_mulitshot_op(msg_listener.as_mut());
+    start_mulitshot_op(&mut msg_listener);
 
     // Send some messages.
     try_send_msg(&sq, msg_token, DATA1).unwrap();
@@ -359,7 +359,7 @@ fn test_multishot_poll() {
     let (mut receiver, mut sender) = pipe2().unwrap();
 
     let mut receiver_read = pin!(multishot_poll(&sq, receiver.as_fd(), libc::POLLIN as _));
-    start_mulitshot_op(Pin::new(&mut receiver_read));
+    start_mulitshot_op(&mut receiver_read);
 
     let mut buf = vec![0; DATA.len() + 1];
     for _ in 0..3 {
@@ -385,7 +385,7 @@ fn cancel_multishot_poll() {
     let (receiver, sender) = pipe2().unwrap();
 
     let mut receiver_read = pin!(multishot_poll(&sq, receiver.as_fd(), libc::POLLIN as _));
-    start_mulitshot_op(receiver_read.as_mut());
+    start_mulitshot_op(&mut receiver_read);
 
     waker.block_on(receiver_read.cancel()).unwrap();
     assert!(waker.block_on(next(receiver_read)).is_none());
@@ -400,7 +400,7 @@ fn drop_multishot_poll() {
 
     let mut receiver_read = multishot_poll(&sq, receiver.as_fd(), libc::POLLIN as _);
 
-    start_mulitshot_op(Pin::new(&mut receiver_read));
+    start_mulitshot_op(&mut receiver_read);
 
     drop(receiver_read);
     drop(receiver);

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -252,7 +252,7 @@ where
 
 /// Start an A10 multishot operation, assumes `iter` is a A10 `AsyncIterator`.
 #[track_caller]
-pub(crate) fn start_mulitshot_op<I>(iter: I)
+pub(crate) fn start_mulitshot_op<I>(iter: &mut I)
 where
     I: AsyncIterator + Unpin,
     I::Item: fmt::Debug,


### PR DESCRIPTION
The flakyness stemmed from the fact that we don't actually know if an operation was started or not, i.e. queued with the kernel.

Closes #128