### PR TITLE
Export Cancel from the root of the crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,8 @@ pub mod poll;
 pub mod process;
 
 use bitmap::AtomicBitMap;
+#[doc(no_inline)]
+pub use cancel::Cancel;
 use config::munmap;
 pub use config::Config;
 #[doc(no_inline)]

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -18,10 +18,9 @@ use std::task::{self, Poll};
 use std::thread::{self, Thread};
 use std::{fmt, mem, panic, process, ptr, str};
 
-use a10::cancel::Cancel;
 use a10::fd::Descriptor;
 use a10::net::socket;
-use a10::{AsyncFd, Ring, SubmissionQueue};
+use a10::{AsyncFd, Cancel, Ring, SubmissionQueue};
 
 /// Initialise logging.
 ///


### PR DESCRIPTION
Makes it easier to discover and use.