### PR TITLE
Add AsyncFd::truncate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ check:
 # * `single-match-else`: prefer match statements over if statements.
 # * `use-self`: strongly disagree.
 # TODO: resolve `cast-possible-truncation` errors.
-# TODO: resolve `manual-c-str-listerals` and `ref-as-ptr` once the related
-# features are a little older (1.77 and 1.76).
+# TODO: resolve `manual-c-str-listerals`, `ref-as-ptr` and `inspect_err` once
+# the related features are a little older (1.77, 1.76 and 1.75).
 lint: clippy
 clippy:
 	cargo clippy --all-features --workspace -- \
@@ -61,6 +61,7 @@ clippy:
 		--allow clippy::ref-as-ptr \
 		--allow clippy::single-match-else \
 		--allow clippy::use-self \
+		--allow clippy::manual-inspect \
 		\
 		--allow clippy::cast-possible-truncation \
 		--allow clippy::cast-possible-wrap \

--- a/src/op.rs
+++ b/src/op.rs
@@ -745,6 +745,12 @@ impl Submission {
         };
     }
 
+    pub(crate) unsafe fn ftruncate(&mut self, fd: RawFd, offset: u64) {
+        self.inner.opcode = libc::IORING_OP_FTRUNCATE as u8;
+        self.inner.fd = fd;
+        self.inner.__bindgen_anon_1 = libc::io_uring_sqe__bindgen_ty_1 { off: offset };
+    }
+
     pub(crate) unsafe fn wake(&mut self, ring_fd: RawFd) {
         self.msg(ring_fd, u64::MAX, 0, 0);
         self.no_completion_event();


### PR DESCRIPTION
Calls `ftruncate(2)`, truncating a file to a specified length.

Closes #125