### PR TITLE
Use DropWaker SubmissionQueue::cancel_op

### DIFF
--- a/src/drop_waker.rs
+++ b/src/drop_waker.rs
@@ -1,0 +1,60 @@
+//! [`DropWaker`] trait and implementations.
+//!
+//! See [`drop_task_waker`].
+
+use std::sync::Arc;
+use std::task;
+
+/// Create a [`task::Waker`] that will drop itself when the waker is dropped.
+///
+/// # Safety
+///
+/// The returned `task::Waker` cannot be cloned, it will panic.
+pub(crate) unsafe fn drop_task_waker<T: DropWaker>(to_drop: T) -> task::Waker {
+    unsafe fn drop_by_ptr<T: DropWaker>(data: *const ()) {
+        T::drop_from_waker_data(data);
+    }
+
+    // SAFETY: we meet the `task::Waker` and `task::RawWaker` requirements.
+    unsafe {
+        task::Waker::from_raw(task::RawWaker::new(
+            to_drop.into_waker_data(),
+            &task::RawWakerVTable::new(
+                |_| panic!("attempted to clone `a10::drop_task_waker`"),
+                // SAFETY: `wake` takes ownership, so dropping is safe.
+                drop_by_ptr::<T>,
+                |_| { /* `wake_by_ref` is a no-op. */ },
+                drop_by_ptr::<T>,
+            ),
+        ))
+    }
+}
+
+/// Trait used by [`drop_task_waker`].
+pub(crate) trait DropWaker {
+    /// Return itself as waker data.
+    fn into_waker_data(self) -> *const ();
+
+    /// Drop the waker `data` created by `into_waker_data`.
+    unsafe fn drop_from_waker_data(data: *const ());
+}
+
+impl<T> DropWaker for Box<T> {
+    fn into_waker_data(self) -> *const () {
+        Box::into_raw(self).cast()
+    }
+
+    unsafe fn drop_from_waker_data(data: *const ()) {
+        drop(Box::<T>::from_raw(data.cast_mut().cast()));
+    }
+}
+
+impl<T> DropWaker for Arc<T> {
+    fn into_waker_data(self) -> *const () {
+        Arc::into_raw(self).cast()
+    }
+
+    unsafe fn drop_from_waker_data(data: *const ()) {
+        drop(Arc::<T>::from_raw(data.cast_mut().cast()));
+    }
+}

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -269,12 +269,16 @@ impl<D: Descriptor> Drop for Open<D> {
                     // `None`, but in that case `self.path` would also be
                     // `None`.
                     let sq = self.sq.as_ref().unwrap();
-                    let result = sq.cancel_op(op_index, path, |submission| unsafe {
-                        submission.cancel_op(op_index);
-                        // We'll get a canceled completion event if we succeeded, which
-                        // is sufficient to cleanup the operation.
-                        submission.no_completion_event();
-                    });
+                    let result = sq.cancel_op(
+                        op_index,
+                        || path,
+                        |submission| unsafe {
+                            submission.cancel_op(op_index);
+                            // We'll get a canceled completion event if we succeeded, which
+                            // is sufficient to cleanup the operation.
+                            submission.no_completion_event();
+                        },
+                    );
                     if let Err(err) = result {
                         log::error!(
                             "dropped a10::Open before completion, attempt to cancel failed: {err}"
@@ -811,12 +815,16 @@ impl Drop for CreateDir {
         if let Some(path) = self.path.take() {
             match self.state {
                 OpState::Running(op_index) => {
-                    let result = self.sq.cancel_op(op_index, path, |submission| unsafe {
-                        submission.cancel_op(op_index);
-                        // We'll get a canceled completion event if we succeeded, which
-                        // is sufficient to cleanup the operation.
-                        submission.no_completion_event();
-                    });
+                    let result = self.sq.cancel_op(
+                        op_index,
+                        || path,
+                        |submission| unsafe {
+                            submission.cancel_op(op_index);
+                            // We'll get a canceled completion event if we succeeded, which
+                            // is sufficient to cleanup the operation.
+                            submission.no_completion_event();
+                        },
+                    );
                     if let Err(err) = result {
                         log::error!("dropped a10::CreateDir before completion, attempt to cancel failed: {err}");
                     }
@@ -909,14 +917,16 @@ impl Drop for Rename {
 
             match self.state {
                 OpState::Running(op_index) => {
-                    let result =
-                        self.sq
-                            .cancel_op(op_index, Box::from((from, to)), |submission| unsafe {
-                                submission.cancel_op(op_index);
-                                // We'll get a canceled completion event if we succeeded, which
-                                // is sufficient to cleanup the operation.
-                                submission.no_completion_event();
-                            });
+                    let result = self.sq.cancel_op(
+                        op_index,
+                        || Box::from((from, to)),
+                        |submission| unsafe {
+                            submission.cancel_op(op_index);
+                            // We'll get a canceled completion event if we succeeded, which
+                            // is sufficient to cleanup the operation.
+                            submission.no_completion_event();
+                        },
+                    );
                     if let Err(err) = result {
                         log::error!("dropped a10::CreateDir before completion, attempt to cancel failed: {err}");
                     }
@@ -1016,12 +1026,16 @@ impl Drop for Delete {
         if let Some(path) = self.path.take() {
             match self.state {
                 OpState::Running(op_index) => {
-                    let result = self.sq.cancel_op(op_index, path, |submission| unsafe {
-                        submission.cancel_op(op_index);
-                        // We'll get a canceled completion event if we succeeded, which
-                        // is sufficient to cleanup the operation.
-                        submission.no_completion_event();
-                    });
+                    let result = self.sq.cancel_op(
+                        op_index,
+                        || path,
+                        |submission| unsafe {
+                            submission.cancel_op(op_index);
+                            // We'll get a canceled completion event if we succeeded, which
+                            // is sufficient to cleanup the operation.
+                            submission.no_completion_event();
+                        },
+                    );
                     if let Err(err) = result {
                         log::error!("dropped a10::CreateDir before completion, attempt to cancel failed: {err}");
                     }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -909,14 +909,14 @@ impl Drop for Rename {
 
             match self.state {
                 OpState::Running(op_index) => {
-                    let result = self
-                        .sq
-                        .cancel_op(op_index, (from, to), |submission| unsafe {
-                            submission.cancel_op(op_index);
-                            // We'll get a canceled completion event if we succeeded, which
-                            // is sufficient to cleanup the operation.
-                            submission.no_completion_event();
-                        });
+                    let result =
+                        self.sq
+                            .cancel_op(op_index, Box::from((from, to)), |submission| unsafe {
+                                submission.cancel_op(op_index);
+                                // We'll get a canceled completion event if we succeeded, which
+                                // is sufficient to cleanup the operation.
+                                submission.no_completion_event();
+                            });
                     if let Err(err) = result {
                         log::error!("dropped a10::CreateDir before completion, attempt to cancel failed: {err}");
                     }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -381,6 +381,7 @@ op_future! {
         /// access it safely.
         buf: B,
     },
+    drop_using: Box,
     setup_state: offset: u64,
     setup: |submission, fd, (buf,), offset| unsafe {
         let (ptr, len) = buf.parts_mut();
@@ -479,6 +480,7 @@ op_future! {
         /// to heap allocation.
         iovecs: [libc::iovec; N],
     },
+    drop_using: Box,
     /// `iovecs` can't move until the kernel has read the submission.
     impl !Unpin,
     setup_state: offset: u64,
@@ -596,6 +598,7 @@ op_future! {
         /// access it safely.
         buf: B,
     },
+    drop_using: Box,
     setup_state: offset: u64,
     setup: |submission, fd, (buf,), offset| unsafe {
         let (ptr, len) = buf.parts();
@@ -723,6 +726,7 @@ op_future! {
         /// to heap allocation.
         iovecs: [libc::iovec; N],
     },
+    drop_using: Box,
     /// `iovecs` can't move until the kernel has read the submission.
     impl !Unpin,
     setup_state: offset: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ use bitmap::AtomicBitMap;
 pub use cancel::Cancel;
 use config::munmap;
 pub use config::Config;
-use drop_waker::{drop_task_waker, DropWaker};
+use drop_waker::{drop_task_waker, DropWake};
 #[doc(no_inline)]
 pub use extract::Extract;
 #[doc(no_inline)]
@@ -826,7 +826,7 @@ impl SubmissionQueue {
     ) -> Result<(), QueueFull>
     where
         F: FnOnce(&mut Submission),
-        T: DropWaker,
+        T: DropWake,
     {
         log::trace!(op_index = op_index.0; "canceling operation");
         if let Some(operation) = self.shared.queued_ops.get(op_index.0) {

--- a/src/net.rs
+++ b/src/net.rs
@@ -483,6 +483,7 @@ op_future! {
         /// access it safely.
         buf: B,
     },
+    drop_using: Box,
     setup_state: flags: (u8, libc::c_int),
     setup: |submission, fd, (buf,), (op, flags)| unsafe {
         let (ptr, len) = buf.parts();
@@ -579,6 +580,7 @@ op_future! {
         /// Address to send to.
         address: A,
     },
+    drop_using: Box,
     setup_state: flags: (u8, libc::c_int),
     setup: |submission, fd, (buf, address), (op, flags)| unsafe {
         let (buf, buf_len) = buf.parts();
@@ -615,6 +617,7 @@ op_future! {
         msg: libc::msghdr,
         iovecs: [libc::iovec; N],
     },
+    drop_using: Box,
     /// `msg` and `iovecs` can't move until the kernel has read the submission.
     impl !Unpin,
     setup_state: flags: (u8, libc::c_int),
@@ -732,6 +735,7 @@ op_future! {
         /// access it safely.
         buf: B,
     },
+    drop_using: Box,
     setup_state: flags: libc::c_int,
     setup: |submission, fd, (buf,), flags| unsafe {
         let (ptr, len) = buf.parts_mut();
@@ -849,6 +853,7 @@ op_future! {
         /// allocation.
         iovecs: [libc::iovec; N],
     },
+    drop_using: Box,
     /// `iovecs` can't move until the kernel has read the submission.
     impl !Unpin,
     setup_state: flags: libc::c_int,
@@ -943,6 +948,7 @@ op_future! {
         /// allocation.
         iovec: libc::iovec,
     },
+    drop_using: Box,
     /// `iovec` can't move until the kernel has read the submission.
     impl !Unpin,
     setup_state: flags: libc::c_int,
@@ -990,6 +996,7 @@ op_future! {
         /// allocation.
         iovecs: [libc::iovec; N],
     },
+    drop_using: Box,
     /// `iovecs` can't move until the kernel has read the submission.
     impl !Unpin,
     setup_state: flags: libc::c_int,

--- a/src/process.rs
+++ b/src/process.rs
@@ -432,7 +432,7 @@ impl Drop for ToSignalsDirect {
                 let signals = unsafe { ManuallyDrop::take(&mut self.signals) };
                 let result = self.signals.fd.sq.cancel_op(
                     op_index,
-                    (signals, direct_fd),
+                    Box::from((signals, direct_fd)),
                     |submission| unsafe {
                         submission.cancel_op(op_index);
                         // We'll get a canceled completion event if we succeeded, which


### PR DESCRIPTION
Instead of always using the Box implementation, meaning we always
allocate, we now require the caller to pass resources that implement
DropWaker.

This means we can avoid the allocation for various types that implement
DropWaker already.