### PR TITLE
Handle EINTR

### DIFF
--- a/src/cq.rs
+++ b/src/cq.rs
@@ -156,4 +156,7 @@ pub(crate) trait OperationState: fmt::Debug {
 
     /// Create a queued multishot operation.
     fn new_multishot() -> Self;
+
+    /// Prepare the operation state for a retry of the operation.
+    fn prep_retry(&mut self);
 }

--- a/src/io_uring/cq.rs
+++ b/src/io_uring/cq.rs
@@ -328,6 +328,16 @@ impl crate::cq::OperationState for OperationState {
             results: Vec::new(),
         }
     }
+
+    fn prep_retry(&mut self) {
+        match self {
+            OperationState::Single { result } => {
+                result.flags = u16::MAX;
+                result.result = i32::MIN;
+            }
+            OperationState::Multishot { .. } => { /* We'll continue to collect the results. */ }
+        }
+    }
 }
 
 /// Completed result of an operation.

--- a/src/kqueue/mod.rs
+++ b/src/kqueue/mod.rs
@@ -647,4 +647,8 @@ impl crate::cq::OperationState for OperationState {
     fn new_multishot() -> OperationState {
         OperationState
     }
+
+    fn prep_retry(&mut self) {
+        *self = OperationState;
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,6 +441,13 @@ impl<T> QueuedOperation<T> {
             self.waker.clone_from(waker);
         }
     }
+
+    fn prep_retry(&mut self)
+    where
+        T: cq::OperationState,
+    {
+        self.state.prep_retry();
+    }
 }
 
 /// Operation id.

--- a/src/op.rs
+++ b/src/op.rs
@@ -500,6 +500,9 @@ impl<R, A> State<R, A> {
 
                 // Retry the operation.
                 update_waker(queued_op_slot.as_mut(), ctx.waker());
+                if let Some(queued_op) = &mut *queued_op_slot {
+                    queued_op.prep_retry();
+                }
                 drop(queued_op_slot); // Unlock.
                 if resubmit {
                     // SAFETY: we've ensured that we own the `op_id`.


### PR DESCRIPTION
When polling or running fd operations it can be quite annoying to deal with EINTR in all call sites. We can do it quite easily in the code itself do by either ignoring it (polling) or retrying the operation.