### PR TITLE
Rewrite msg module

### DIFF
--- a/src/io_uring/cq.rs
+++ b/src/io_uring/cq.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use std::{fmt, io, ptr};
 
 use crate::io_uring::{self, libc, load_atomic_u32, mmap, munmap, Shared};
-use crate::msg::MsgData;
+use crate::msg::Message;
 use crate::op::OpResult;
 use crate::{debug_detail, syscall, OperationId};
 
@@ -363,8 +363,8 @@ impl CompletionResult {
     }
 
     #[allow(clippy::cast_sign_loss)]
-    pub(crate) const fn as_msg(self) -> MsgData {
-        self.result as MsgData
+    pub(crate) const fn as_msg(self) -> Message {
+        self.result as Message
     }
 }
 

--- a/src/io_uring/msg.rs
+++ b/src/io_uring/msg.rs
@@ -1,10 +1,10 @@
 use std::os::fd::AsRawFd;
 
 use crate::io_uring::{cq, libc, sq};
-use crate::msg::MsgData;
+use crate::msg::Message;
 use crate::{OperationId, SubmissionQueue};
 
-pub(crate) fn next(state: &mut cq::OperationState) -> Option<MsgData> {
+pub(crate) fn next(state: &mut cq::OperationState) -> Option<Message> {
     let result = match state {
         cq::OperationState::Single { result } => *result,
         cq::OperationState::Multishot { results } if results.is_empty() => return None,
@@ -16,7 +16,7 @@ pub(crate) fn next(state: &mut cq::OperationState) -> Option<MsgData> {
 pub(crate) fn send(
     sq: &SubmissionQueue,
     op_id: OperationId,
-    data: MsgData,
+    data: Message,
     submission: &mut sq::Submission,
 ) {
     submission.0.opcode = libc::IORING_OP_MSG_RING as u8;

--- a/tests/ring.rs
+++ b/tests/ring.rs
@@ -18,10 +18,9 @@ use std::time::{Duration, Instant};
 use a10::fs::{Open, OpenOptions};
 use a10::io::ReadBufPool;
 use a10::mem::{self, AdviseFlag};
-use a10::msg::{msg_listener, MsgListener, MsgSender, SendMsg};
 use a10::poll::{multishot_poll, oneshot_poll, Interest, MultishotPoll, OneshotPoll};
 use a10::process::{self, ChildStatus, Signal, WaitOption};
-use a10::{Config, Ring, SubmissionQueue};
+use a10::{msg, Config, Ring, SubmissionQueue};
 
 mod util;
 use util::{
@@ -259,25 +258,25 @@ fn message_sending() {
     let sq = test_queue();
     let waker = Waker::new();
 
-    is_send::<MsgListener>();
-    is_sync::<MsgListener>();
-    is_send::<MsgSender>();
-    is_sync::<MsgSender>();
-    is_send::<SendMsg>();
-    is_sync::<SendMsg>();
+    is_send::<msg::Listener>();
+    is_sync::<msg::Listener>();
+    is_send::<msg::Sender>();
+    is_sync::<msg::Sender>();
+    is_send::<msg::SendMsg>();
+    is_sync::<msg::SendMsg>();
 
-    let (msg_listener, msg_sender) = msg_listener(sq.clone()).unwrap();
-    let mut msg_listener = pin!(msg_listener);
-    start_mulitshot_op(&mut msg_listener);
+    let (listener, sender) = msg::listener(sq.clone()).unwrap();
+    let mut listener = pin!(listener);
+    start_mulitshot_op(&mut listener);
 
     // Send some messages.
-    msg_sender.try_send(DATA1).unwrap();
-    waker.block_on(pin!(msg_sender.send(DATA2))).unwrap();
+    sender.try_send(DATA1).unwrap();
+    waker.block_on(pin!(sender.send(DATA2))).unwrap();
 
-    assert_eq!(waker.block_on(next(msg_listener.as_mut())), Some(DATA1));
-    assert_eq!(waker.block_on(next(msg_listener.as_mut())), Some(DATA2));
+    assert_eq!(waker.block_on(next(listener.as_mut())), Some(DATA1));
+    assert_eq!(waker.block_on(next(listener.as_mut())), Some(DATA2));
 
-    assert!(poll_nop(Pin::new(&mut next(msg_listener.as_mut()))).is_pending());
+    assert!(poll_nop(Pin::new(&mut next(listener.as_mut()))).is_pending());
 }
 
 #[test]

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -398,7 +398,7 @@ macro_rules! op_async_iter {
     };
 }
 
-op_async_iter!(a10::msg::MsgListener => u32);
+op_async_iter!(a10::msg::Listener => u32);
 op_async_iter!(a10::net::MultishotAccept<'_> => io::Result<AsyncFd>);
 op_async_iter!(a10::net::MultishotRecv<'_> => io::Result<a10::io::ReadBuf>);
 op_async_iter!(a10::poll::MultishotPoll => io::Result<a10::poll::Event>);


### PR DESCRIPTION
This series of commits makes changes to the msg module so that it's easier to use (or rather harder to misuse) and make various naming changes.

The lose functions and types, such as (try_)send_msg and MsgToken, are remove and moved into a new type called msg::Listener. This combines a SubmissionQueue and MsgToken (now just OperationId) to ensure the sender always sends to the correct listener.

It also drops the "msg" prefix from the types in the module. 