### PR TITLE
Fix io_uring::Shared::unsubmitted

### DIFF
--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -215,7 +215,12 @@ impl Shared {
 
     /// Returns the number of unsumitted submission queue entries.
     pub(crate) fn unsubmitted(&self) -> u32 {
-        self.pending_tail() - self.kernel_read()
+        // NOTE: we MUST load the head before the tail to ensure the head is
+        // ALWAYS older. Otherwise it's possible for the subtraction to
+        // underflow.
+        let head = self.kernel_read();
+        let tail = self.pending_tail();
+        tail - head
     }
 
     /// Returns `self.kernel_read`.


### PR DESCRIPTION
We need to read the head (written by the kernel) before the tail (written by us) to ensure it's not possible that the head is larger than the tail.

This is possible if
1. we read the tail first,
2. another threads submits an operation,
3. the kernel processes the submission and updates the head
4. we read the head

We've read tail = N, while it's updated to N + 1, and we read the head = N + 1. Which means that tail - head = -1.