### PR TITLE
Rename Ring::submission_queue to sq

### DIFF
--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -16,7 +16,7 @@ fn main() -> io::Result<()> {
     // Create a new I/O uring.
     let mut ring = a10::Ring::new(1)?;
     // Get an owned reference to the submission queue.
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     // Collect the files we want to concatenate.
     let mut filenames: Vec<String> = args().skip(1).collect();

--- a/examples/cp.rs
+++ b/examples/cp.rs
@@ -18,7 +18,7 @@ fn main() -> io::Result<()> {
     // Create a new I/O uring.
     let mut ring = a10::Ring::new(1)?;
     // Get an owned reference to the submission queue.
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     // Collect the files we want to concatenate.
     let mut args = args().skip(1);

--- a/examples/http_client.rs
+++ b/examples/http_client.rs
@@ -33,7 +33,7 @@ fn main() -> io::Result<()> {
         .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "failed to lookup ip"))?;
 
     // Create our future that makes the request.
-    let request_future = request(ring.submission_queue().clone(), &host, address);
+    let request_future = request(ring.sq().clone(), &host, address);
 
     // Use our fake runtime to poll the future.
     let response = runtime::block_on(&mut ring, request_future)?;

--- a/examples/read_file.rs
+++ b/examples/read_file.rs
@@ -20,7 +20,7 @@ fn main() -> io::Result<()> {
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "missing argument"))?;
 
     // Create our future that reads the file.
-    let read_file_future = read_file(ring.submission_queue().clone(), path);
+    let read_file_future = read_file(ring.sq().clone(), path);
 
     // Use our fake runtime to poll the future.
     let data = runtime::block_on(&mut ring, read_file_future)?;

--- a/src/io_uring/config.rs
+++ b/src/io_uring/config.rs
@@ -211,7 +211,7 @@ impl<'r> crate::Config<'r> {
     /// Uses `IORING_SETUP_ATTACH_WQ`, added in Linux kernel 5.6.
     #[doc(alias = "IORING_SETUP_ATTACH_WQ")]
     pub const fn attach(self, other_ring: &'r Ring) -> Self {
-        self.attach_queue(other_ring.submission_queue())
+        self.attach_queue(other_ring.sq())
     }
 
     /// Same as [`Config::attach`], but accepts a [`SubmissionQueue`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ impl Ring {
     /// Returns the `SubmissionQueue` used by this ring.
     ///
     /// The `SubmissionQueue` can be used to queue asynchronous I/O operations.
-    pub const fn submission_queue(&self) -> &SubmissionQueue {
+    pub const fn sq(&self) -> &SubmissionQueue {
         &self.sq
     }
 
@@ -211,7 +211,7 @@ impl Ring {
 ///
 /// This type doesn't have many public methods, but is used by all I/O types, to
 /// queue asynchronous operations. The queue can be acquired by using
-/// [`Ring::submission_queue`].
+/// [`Ring::sq`].
 ///
 /// The submission queue can be shared by cloning it, it's a cheap operation.
 #[derive(Clone)]

--- a/src/process.rs
+++ b/src/process.rs
@@ -184,7 +184,7 @@ operation!(
 /// # fn main() {
 /// async fn main() -> io::Result<()> {
 ///     let ring = Ring::new(128)?;
-///     let sq = ring.submission_queue().clone();
+///     let sq = ring.sq().clone();
 ///
 ///     // Create a new `Signals` instance.
 ///     let signals = Signals::from_signals(sq, [Signal::INTERRUPT, Signal::QUIT, Signal::TERMINATION])?;

--- a/tests/async_fd/io.rs
+++ b/tests/async_fd/io.rs
@@ -63,7 +63,7 @@ fn read_read_buf_pool() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     let test_file = &LOREM_IPSUM_50;
     let buf_pool = ReadBufPool::new(sq.clone(), 2, BUF_SIZE as u32).unwrap();
@@ -86,7 +86,7 @@ fn read_buf() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     let test_file = &LOREM_IPSUM_50;
     let buf_pool = ReadBufPool::new(sq.clone(), 2, BUF_SIZE as u32).unwrap();
@@ -155,7 +155,7 @@ fn read_read_buf_pool_multiple_buffers() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     let test_file = &LOREM_IPSUM_50;
     let buf_pool = ReadBufPool::new(sq.clone(), 2, BUF_SIZE as u32).unwrap();
@@ -187,7 +187,7 @@ fn read_read_buf_pool_reuse_buffers() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     let test_file = &LOREM_IPSUM_50;
     let buf_pool = ReadBufPool::new(sq.clone(), 2, BUF_SIZE as u32).unwrap();
@@ -211,7 +211,7 @@ fn read_read_buf_pool_reuse_same_buffer() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     let test_file = &LOREM_IPSUM_50;
     let buf_pool = ReadBufPool::new(sq.clone(), 2, BUF_SIZE as u32).unwrap();
@@ -244,7 +244,7 @@ fn read_read_buf_pool_out_of_buffers() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     let test_file = &LOREM_IPSUM_50;
     let buf_pool = ReadBufPool::new(sq.clone(), 2, BUF_SIZE as u32).unwrap();
@@ -284,7 +284,7 @@ fn two_read_buf_pools() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
     let test_file = &LOREM_IPSUM_50;
 
     let buf_pool1 = ReadBufPool::new(sq.clone(), 2, BUF_SIZE as u32).unwrap();
@@ -311,7 +311,7 @@ fn read_buf_remove() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     let buf_pool = ReadBufPool::new(sq.clone(), 1, BUF_SIZE as u32).unwrap();
 
@@ -387,7 +387,7 @@ fn read_buf_remove_invalid_range() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     let buf_pool = ReadBufPool::new(sq.clone(), 1, BUF_SIZE as u32).unwrap();
 

--- a/tests/async_fd/net.rs
+++ b/tests/async_fd/net.rs
@@ -435,7 +435,7 @@ fn recv_read_buf_pool() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
     let buf_pool = ReadBufPool::new(sq.clone(), 2, BUF_SIZE as u32).unwrap();
 
     // Bind a socket.
@@ -468,7 +468,7 @@ fn recv_read_buf_pool_send_read_buf() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
     let buf_pool = ReadBufPool::new(sq.clone(), 2, BUF_SIZE as u32).unwrap();
 
     // Bind a socket.
@@ -513,7 +513,7 @@ fn multishot_recv() {
     is_sync::<MultishotRecv>();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
     let buf_pool = ReadBufPool::new(sq.clone(), BUFS as u16, BUF_SIZE as u32).unwrap();
 
     // Bind a socket.
@@ -556,7 +556,7 @@ fn multishot_recv_large_send() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
     let buf_pool = ReadBufPool::new(sq.clone(), BUFS as u16, BUF_SIZE as u32).unwrap();
 
     // Bind a socket.
@@ -602,7 +602,7 @@ fn multishot_recv_all_buffers_used() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
     let buf_pool = ReadBufPool::new(sq.clone(), BUFS as u16, BUF_SIZE as u32).unwrap();
 
     // Bind a socket.
@@ -826,7 +826,7 @@ fn recv_from_read_buf_pool() {
     init();
 
     let mut ring = Ring::new(2).expect("failed to create test ring");
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
     let buf_pool = ReadBufPool::new(sq.clone(), 2, BUF_SIZE as u32).unwrap();
 
     // Bind a socket.

--- a/tests/ring.rs
+++ b/tests/ring.rs
@@ -71,7 +71,7 @@ fn submission_queue_full_is_handled_internally() {
 
     init();
     let mut ring = Ring::new(2).unwrap();
-    let sq = ring.submission_queue();
+    let sq = ring.sq();
     let path = LOREM_IPSUM_50.path;
     let expected = LOREM_IPSUM_50.content;
 
@@ -172,13 +172,12 @@ fn config_single_issuer() {
     let ring = Ring::config(1).single_issuer().build().unwrap();
 
     // This is fine.
-    let buf_pool = ReadBufPool::new(ring.submission_queue().clone(), 2, BUF_SIZE as u32).unwrap();
+    let buf_pool = ReadBufPool::new(ring.sq().clone(), 2, BUF_SIZE as u32).unwrap();
     drop(buf_pool);
 
     thread::spawn(move || {
         // This is not (we're on a different thread).
-        let err =
-            ReadBufPool::new(ring.submission_queue().clone(), 2, BUF_SIZE as u32).unwrap_err();
+        let err = ReadBufPool::new(ring.sq().clone(), 2, BUF_SIZE as u32).unwrap_err();
         assert_eq!(err.raw_os_error(), Some(libc::EEXIST));
     })
     .join()
@@ -196,8 +195,7 @@ fn config_single_issuer_disabled_ring() {
         ring.enable().unwrap();
 
         // Since this thread enabled the ring, this is now fine.
-        let buf_pool =
-            ReadBufPool::new(ring.submission_queue().clone(), 2, BUF_SIZE as u32).unwrap();
+        let buf_pool = ReadBufPool::new(ring.sq().clone(), 2, BUF_SIZE as u32).unwrap();
         drop(buf_pool);
     })
     .join()
@@ -226,7 +224,7 @@ fn wake_ring() {
         .with_idle_timeout(Duration::from_millis(1))
         .build()
         .unwrap();
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     let handle = thread::spawn(move || {
         thread::sleep(Duration::from_millis(10));
@@ -242,7 +240,7 @@ fn wake_ring() {
 fn wake_ring_after_ring_dropped() {
     init();
     let ring = Ring::new(2).unwrap();
-    let sq = ring.submission_queue().clone();
+    let sq = ring.sq().clone();
 
     drop(ring);
     sq.wake();

--- a/tests/signals.rs
+++ b/tests/signals.rs
@@ -128,7 +128,7 @@ struct TestHarness {
 impl TestHarness {
     fn setup(quiet: bool) -> TestHarness {
         let ring = Ring::config(2).with_direct_descriptors(2).build().unwrap();
-        let sq = ring.submission_queue().clone();
+        let sq = ring.sq().clone();
         TestHarness {
             ring,
             signals: Some(Signals::from_signals(sq, SIGNALS).unwrap()),

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -106,7 +106,7 @@ pub(crate) fn test_queue() -> SubmissionQueue {
                     }
                 }
             };
-            let sq = ring.submission_queue().clone();
+            let sq = ring.sq().clone();
             thread::spawn(move || {
                 let res = panic::catch_unwind(move || {
                     loop {


### PR DESCRIPTION
It's shorter. Yes, that's the whole reason.