### PR TITLE
Add StaticBuf

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -62,7 +62,7 @@ mod read_buf;
 mod traits;
 
 pub use read_buf::{ReadBuf, ReadBufPool};
-pub use traits::{Buf, BufMut, BufMutSlice, BufSlice, IoMutSlice, IoSlice};
+pub use traits::{Buf, BufMut, BufMutSlice, BufSlice, IoMutSlice, IoSlice, StaticBuf};
 #[allow(unused_imports)] // Not used by all OS.
 pub(crate) use traits::{BufGroupId, BufId};
 // Re-export so we don't have to worry about import `std::io` and `crate::io`.


### PR DESCRIPTION
This type shouldn't be needed, but it is. It works around "implementation of `Buf` is not general enough" errors that rustc sometimes throws up when working with Send async functions..