### PR TITLE
Use Buf::as_slice for StaticBuf

### DIFF
--- a/src/io/traits.rs
+++ b/src/io/traits.rs
@@ -820,6 +820,6 @@ unsafe impl Buf for StaticBuf {
     }
 
     fn as_slice(&self) -> &[u8] {
-        self.0.as_slice()
+        Buf::as_slice(&self.0)
     }
 }


### PR DESCRIPTION
Rustc was complaing that the as_slice method name may conflict with a new method introduced in the str_as_str feature. To avoid breaking in the future this ensure we call the method we expect to call.