### PR TITLE
Remove 2 suffix from AsyncFd::(set_)socket_option2

### DIFF
--- a/src/io_uring/net.rs
+++ b/src/io_uring/net.rs
@@ -608,9 +608,9 @@ impl FdIter for MultishotAcceptOp {
     }
 }
 
-pub(crate) struct SocketOption2Op<T>(PhantomData<*const T>);
+pub(crate) struct SocketOptionOp<T>(PhantomData<*const T>);
 
-impl<T: option::Get> FdOp for SocketOption2Op<T> {
+impl<T: option::Get> FdOp for SocketOptionOp<T> {
     type Output = T::Output;
     type Resources = OptionStorage<MaybeUninit<T::Storage>>;
     type Args = (Level, Opt);
@@ -655,9 +655,9 @@ impl<T: option::Get> FdOp for SocketOption2Op<T> {
     }
 }
 
-pub(crate) struct SetSocketOption2Op<T>(PhantomData<*const T>);
+pub(crate) struct SetSocketOptionOp<T>(PhantomData<*const T>);
 
-impl<T: option::Set> FdOp for SetSocketOption2Op<T> {
+impl<T: option::Set> FdOp for SetSocketOptionOp<T> {
     type Output = ();
     type Resources = OptionStorage<T::Storage>;
     type Args = (Level, Opt);

--- a/src/kqueue/net.rs
+++ b/src/kqueue/net.rs
@@ -536,9 +536,9 @@ impl<A: SocketAddress> FdOp for AcceptOp<A> {
     }
 }
 
-pub(crate) struct SocketOption2Op<T>(PhantomData<*const T>);
+pub(crate) struct SocketOptionOp<T>(PhantomData<*const T>);
 
-impl<T: option::Get> DirectFdOp for SocketOption2Op<T> {
+impl<T: option::Get> DirectFdOp for SocketOptionOp<T> {
     type Output = T::Output;
     type Resources = OptionStorage<MaybeUninit<T::Storage>>;
     type Args = (Level, Opt);
@@ -562,11 +562,11 @@ impl<T: option::Get> DirectFdOp for SocketOption2Op<T> {
     }
 }
 
-impl_fd_op!(SocketOption2Op<T>);
+impl_fd_op!(SocketOptionOp<T>);
 
-pub(crate) struct SetSocketOption2Op<T>(PhantomData<*const T>);
+pub(crate) struct SetSocketOptionOp<T>(PhantomData<*const T>);
 
-impl<T: option::Set> DirectFdOp for SetSocketOption2Op<T> {
+impl<T: option::Set> DirectFdOp for SetSocketOptionOp<T> {
     type Output = ();
     type Resources = OptionStorage<T::Storage>;
     type Args = (Level, Opt);
@@ -587,7 +587,7 @@ impl<T: option::Set> DirectFdOp for SetSocketOption2Op<T> {
     }
 }
 
-impl_fd_op!(SetSocketOption2Op<T>);
+impl_fd_op!(SetSocketOptionOp<T>);
 
 pub(crate) struct ShutdownOp;
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -362,25 +362,28 @@ impl AsyncFd {
     }
 
     /// Get socket option.
+    ///
+    /// At the time of writing this is limited to the `SOL_SOCKET` level for
+    /// io_uring.
     #[doc = man_link!(getsockopt(2))]
     #[doc(alias = "getsockopt")]
-    pub fn socket_option2<'fd, T>(&'fd self) -> SocketOption2<'fd, T>
-    where
-        T: option::Get,
-    {
+    pub fn socket_option<'fd, T: option::Get>(&'fd self) -> SocketOption<'fd, T> {
         let value = OptionStorage(MaybeUninit::uninit());
-        SocketOption2::new(self, value, (T::LEVEL, T::OPT))
+        SocketOption::new(self, value, (T::LEVEL, T::OPT))
     }
 
     /// Set socket option.
+    ///
+    /// At the time of writing this is limited to the `SOL_SOCKET` level for
+    /// io_uring.
     #[doc = man_link!(setsockopt(2))]
     #[doc(alias = "setsockopt")]
-    pub fn set_socket_option2<'fd, T>(&'fd self, value: T::Value) -> SetSocketOption2<'fd, T>
-    where
-        T: option::Set,
-    {
+    pub fn set_socket_option<'fd, T: option::Set>(
+        &'fd self,
+        value: T::Value,
+    ) -> SetSocketOption<'fd, T> {
         let value = OptionStorage(T::as_storage(value));
-        SetSocketOption2::new(self, value, (T::LEVEL, T::OPT))
+        SetSocketOption::new(self, value, (T::LEVEL, T::OPT))
     }
 
     /// Shuts down the read, write, or both halves of this connection.
@@ -947,11 +950,11 @@ fd_operation! {
     /// [`Future`] behind [`AsyncFd::accept`].
     pub struct Accept<A: SocketAddress>(sys::net::AcceptOp<A>) -> io::Result<(AsyncFd, A)>;
 
-    /// [`Future`] behind [`AsyncFd::socket_option2`].
-    pub struct SocketOption2<T: option::Get>(sys::net::SocketOption2Op<T>) -> io::Result<T::Output>;
+    /// [`Future`] behind [`AsyncFd::socket_option`].
+    pub struct SocketOption<T: option::Get>(sys::net::SocketOptionOp<T>) -> io::Result<T::Output>;
 
-    /// [`Future`] behind [`AsyncFd::set_socket_option2`].
-    pub struct SetSocketOption2<T: option::Set>(sys::net::SetSocketOption2Op<T>) -> io::Result<()>;
+    /// [`Future`] behind [`AsyncFd::set_socket_option`].
+    pub struct SetSocketOption<T: option::Set>(sys::net::SetSocketOptionOp<T>) -> io::Result<()>;
 
     /// [`Future`] behind [`AsyncFd::shutdown`].
     pub struct Shutdown(sys::net::ShutdownOp) -> io::Result<()>;

--- a/src/net/option.rs
+++ b/src/net/option.rs
@@ -1,9 +1,9 @@
 //! Socket options.
 //!
-//! See [`AsyncFd::socket_option2`] and [`AsyncFd::set_socket_option2`].
+//! See [`AsyncFd::socket_option`] and [`AsyncFd::set_socket_option`].
 //!
-//! [`AsyncFd::socket_option2`]: crate::fd::AsyncFd::socket_option2
-//! [`AsyncFd::set_socket_option2`]: crate::fd::AsyncFd::set_socket_option2
+//! [`AsyncFd::socket_option`]: crate::fd::AsyncFd::socket_option
+//! [`AsyncFd::set_socket_option`]: crate::fd::AsyncFd::set_socket_option
 
 use std::io;
 use std::mem::MaybeUninit;
@@ -12,9 +12,9 @@ use crate::net::{self, Level, Opt, SocketOpt};
 
 /// Trait that defines how get the value of a socket option.
 ///
-/// See [`AsyncFd::socket_option2`].
+/// See [`AsyncFd::socket_option`].
 ///
-/// [`AsyncFd::socket_option2`]: crate::fd::AsyncFd::socket_option2
+/// [`AsyncFd::socket_option`]: crate::fd::AsyncFd::socket_option
 pub trait Get {
     /// Returned output.
     type Output: Sized;
@@ -53,9 +53,9 @@ pub trait Get {
 
 /// Trait that defines how set the value of a socket option.
 ///
-/// See [`AsyncFd::set_socket_option2`].
+/// See [`AsyncFd::set_socket_option`].
 ///
-/// [`AsyncFd::set_socket_option2`]: crate::fd::AsyncFd::set_socket_option2
+/// [`AsyncFd::set_socket_option`]: crate::fd::AsyncFd::set_socket_option
 pub trait Set {
     /// Value to set.
     type Value: Sized;

--- a/tests/functional/net_options.rs
+++ b/tests/functional/net_options.rs
@@ -1,74 +1,19 @@
 use std::fmt;
 
-use a10::net::{
-    Domain, Level, Protocol, SetSocketOption, SetSocketOption2, SocketOpt, SocketOption,
-    SocketOption2, Type, option,
-};
+use a10::net::{Domain, Protocol, SetSocketOption, SocketOption, Type, option};
 
 use crate::util::{Waker, is_send, is_sync, new_socket, test_queue};
 
 #[test]
 fn async_fd_socket_option_is_send_and_sync() {
-    is_send::<SocketOption<libc::c_int>>();
-    is_sync::<SocketOption<libc::c_int>>();
-}
-
-#[test]
-fn async_fd_set_socket_option_is_send_and_sync() {
-    is_send::<SetSocketOption<libc::c_int>>();
-    is_sync::<SetSocketOption<libc::c_int>>();
-}
-
-#[test]
-fn async_fd_socket_option2_is_send_and_sync() {
-    is_send::<SocketOption2<option::ReuseAddress>>();
-    is_sync::<SocketOption2<option::ReuseAddress>>();
+    is_send::<SocketOption<option::ReuseAddress>>();
+    is_sync::<SocketOption<option::ReuseAddress>>();
 }
 
 #[test]
 fn async_fd_set_socket_options_is_send_and_sync() {
-    is_send::<SetSocketOption2<option::ReuseAddress>>();
-    is_sync::<SetSocketOption2<option::ReuseAddress>>();
-}
-
-#[test]
-fn socket_option() {
-    let sq = test_queue();
-    let waker = Waker::new();
-
-    let socket = waker.block_on(new_socket(sq, Domain::IPV4, Type::STREAM, None));
-
-    #[cfg(any(target_os = "android", target_os = "linux"))]
-    {
-        let got_domain = waker
-            .block_on(socket.socket_option(Level::SOCKET, SocketOpt::DOMAIN))
-            .unwrap();
-        assert_eq!(libc::AF_INET, got_domain);
-    }
-
-    let got_type = waker
-        .block_on(socket.socket_option(Level::SOCKET, SocketOpt::TYPE))
-        .unwrap();
-    assert_eq!(libc::SOCK_STREAM, got_type);
-
-    #[cfg(any(target_os = "android", target_os = "linux"))]
-    {
-        let got_protocol = waker
-            .block_on(socket.socket_option(Level::SOCKET, SocketOpt::PROTOCOL))
-            .unwrap();
-        assert_eq!(libc::IPPROTO_TCP, got_protocol);
-    }
-
-    let got_linger = waker
-        .block_on(socket.socket_option::<libc::linger>(Level::SOCKET, SocketOpt::LINGER))
-        .unwrap();
-    assert_eq!(0, got_linger.l_onoff);
-    assert_eq!(0, got_linger.l_linger);
-
-    let got_error = waker
-        .block_on(socket.socket_option::<libc::c_int>(Level::SOCKET, SocketOpt::ERROR))
-        .unwrap();
-    assert_eq!(0, got_error);
+    is_send::<SetSocketOption<option::ReuseAddress>>();
+    is_sync::<SetSocketOption<option::ReuseAddress>>();
 }
 
 #[test]
@@ -116,7 +61,7 @@ fn test_socket_option<T: option::Get, F: FnOnce(T::Output)>(assert: F) {
     ));
 
     let got = waker
-        .block_on(socket.socket_option2::<T>())
+        .block_on(socket.socket_option::<T>())
         .expect("failed to get socket option");
     assert(got);
 }
@@ -158,16 +103,16 @@ where
     let socket = waker.block_on(new_socket(sq, Domain::IPV4, Type::STREAM, None));
 
     let got_initial = waker
-        .block_on(socket.socket_option2::<T>())
+        .block_on(socket.socket_option::<T>())
         .expect("failed to get initial socket option");
     assert_eq!(got_initial, expected_initial);
 
     waker
-        .block_on(socket.set_socket_option2::<T>(set))
+        .block_on(socket.set_socket_option::<T>(set))
         .expect("failed to set socket option");
 
     let got = waker
-        .block_on(socket.socket_option2::<T>())
+        .block_on(socket.socket_option::<T>())
         .expect("failed to get socket option");
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
This makes the net::option::{Get,Set} traits fully public to they can be used outside of the A10 crate.

Closes #221