### PR TITLE
Use io::ErrorKind::ResourceBusy for QueueFull

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ rust-version  = "1.91"
 default = []
 # Enables nightly only features.
 # * Enables usage of the `AsyncIterator` trait (`async_iterator`).
-# * Returns more accurate `io::ErrorKind`s for certain errors (`io_error_more`).
 nightly = []
 
 [dependencies]

--- a/src/io_uring/sq.rs
+++ b/src/io_uring/sq.rs
@@ -142,12 +142,8 @@ impl Submissions {
 pub(crate) struct QueueFull;
 
 impl From<QueueFull> for io::Error {
-    fn from(_: QueueFull) -> io::Error {
-        #[cfg(not(feature = "nightly"))]
-        let kind = io::ErrorKind::Other;
-        #[cfg(feature = "nightly")]
-        let kind = io::ErrorKind::ResourceBusy;
-        io::Error::new(kind, "submission queue is full")
+    fn from(QueueFull: QueueFull) -> io::Error {
+        io::Error::new(io::ErrorKind::ResourceBusy, "submission queue is full")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,10 +33,7 @@
 //!
 //! [available online on GitHub]: https://github.com/Thomasdezeeuw/a10/tree/main/examples
 
-#![cfg_attr(
-    feature = "nightly",
-    feature(async_iterator, cfg_sanitize, io_error_more)
-)]
+#![cfg_attr(feature = "nightly", feature(async_iterator, cfg_sanitize))]
 
 use std::ptr;
 use std::time::Duration;


### PR DESCRIPTION
Also removes the io_error_more feature when the nightly feature is enabled.

Closes #71