### PR TITLE
Add BufMut::(has_)spare_capacity

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -701,6 +701,14 @@ unsafe impl<B: BufMut> BufMut for ReadNBuf<B> {
         unsafe { self.buf.set_init(n) };
     }
 
+    fn spare_capacity(&self) -> u32 {
+        self.buf.spare_capacity()
+    }
+
+    fn has_spare_capacity(&self) -> bool {
+        self.buf.has_spare_capacity()
+    }
+
     #[cfg(any(target_os = "android", target_os = "linux"))]
     unsafe fn buffer_init(&mut self, id: BufId, n: u32) {
         self.last_read = n as usize;

--- a/src/io/read_buf.rs
+++ b/src/io/read_buf.rs
@@ -329,6 +329,22 @@ unsafe impl BufMut for ReadBuf {
         }
     }
 
+    fn spare_capacity(&self) -> u32 {
+        if let Some(ptr) = self.owned {
+            (self.capacity() - ptr.len()) as u32
+        } else {
+            0
+        }
+    }
+
+    fn has_spare_capacity(&self) -> bool {
+        if let Some(ptr) = self.owned {
+            self.capacity() > ptr.len()
+        } else {
+            false
+        }
+    }
+
     #[allow(private_interfaces)]
     fn parts(&mut self) -> BufMutParts {
         if let Some(ptr) = self.owned {

--- a/src/io/traits.rs
+++ b/src/io/traits.rs
@@ -67,6 +67,18 @@ pub unsafe trait BufMut: 'static {
     /// by [`BufMut::parts_mut`], are initialised.
     unsafe fn set_init(&mut self, n: usize);
 
+    /// Returns the amount of unused bytes in the buffer.
+    ///
+    /// This must be the same length as returned by [`parts_mut`].
+    ///
+    /// [`parts_mut`]: BufMut::parts_mut
+    fn spare_capacity(&self) -> u32;
+
+    /// Returns `true` if the buffer has spare capacity.
+    fn has_spare_capacity(&self) -> bool {
+        self.spare_capacity() != 0
+    }
+
     /// **Not part of the public API**.
     /// Do **not** implement this.
     #[doc(hidden)]
@@ -218,6 +230,14 @@ unsafe impl BufMut for Vec<u8> {
 
     unsafe fn set_init(&mut self, n: usize) {
         unsafe { self.set_len(self.len() + n) };
+    }
+
+    fn spare_capacity(&self) -> u32 {
+        (self.capacity() - self.len()) as u32
+    }
+
+    fn has_spare_capacity(&self) -> bool {
+        self.capacity() > self.len()
     }
 }
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -561,6 +561,10 @@ unsafe impl BufMut for BadReadBuf {
     unsafe fn set_init(&mut self, n: usize) {
         unsafe { self.data.set_init(n) };
     }
+
+    fn spare_capacity(&self) -> u32 {
+        unreachable!("not implemented");
+    }
 }
 
 // NOTE: this implementation is BROKEN! It's only used to test the write_all


### PR DESCRIPTION
Returns how much spare capacity the buffer has and a potentially optimised version that check if there is any spare capacity.