### PR TITLE
Fix SubmissionQueue::wake with single issuer enabled

### DIFF
--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -76,6 +76,9 @@ pub(crate) struct Shared {
     /// True if we're using a kernel thread to do submission polling, i.e. if
     /// `IORING_SETUP_SQPOLL` is enabled.
     kernel_thread: bool,
+    /// True if only a single thread can submit submissions, i.e. if
+    /// `IORING_SETUP_SINGLE_ISSUER` is enabled.
+    single_issuer: bool,
     /// Boolean indicating a thread is [`Ring::poll`]ing.
     ///
     /// [`Ring::poll`]: crate::Ring::poll
@@ -130,6 +133,7 @@ impl Shared {
             submissions_lock: Mutex::new(()),
             submissions_len: parameters.sq_entries,
             kernel_thread: (parameters.flags & libc::IORING_SETUP_SQPOLL) != 0,
+            single_issuer: (parameters.flags & libc::IORING_SETUP_SINGLE_ISSUER) != 0,
             is_polling: AtomicBool::new(false),
             blocked_futures: Mutex::new(Vec::new()),
             rfd,

--- a/tests/functional/ring.rs
+++ b/tests/functional/ring.rs
@@ -206,6 +206,27 @@ fn wake_ring_no_kernel_thread() {
 }
 
 #[test]
+#[cfg(any(target_os = "android", target_os = "linux"))]
+fn wake_ring_with_single_issuer() {
+    init();
+
+    let mut ring = Ring::config()
+        .single_issuer()
+        .defer_task_run()
+        .build()
+        .unwrap();
+    let sq = ring.sq();
+
+    let handle = thread::spawn(move || {
+        sq.wake();
+    });
+
+    // Should be awoken by the wake call above.
+    ring.poll(None).unwrap();
+    handle.join().unwrap();
+}
+
+#[test]
 fn wake_ring_after_ring_dropped() {
     init();
     let ring = Ring::new().unwrap();


### PR DESCRIPTION
When single issuer is enabled we can only submit submissions from a single thread. So when we try to wake from another thread that would result in an EEXIST error not achieving the goal of waking the ring.

To solve this we send a wake up synchronously without the use of a ring.