### PR TITLE
Various improvements to the fs::notify kqueue implementation

### DIFF
--- a/src/fs/notify.rs
+++ b/src/fs/notify.rs
@@ -58,17 +58,9 @@
 //!
 //! Not all interests are supported. Events for opening or closing a file, and
 //! reading from a file are only supported on FreeBSD & NetBSD, not on e.g.
-//! OpenBSD or macOS. Events for moving a file out of a directory don't work,
-//! only for moving the directory itself.
-//!
-//! For watched directories it's not possible to determine *what* happened to
-//! the directory. For example if a file is created in the directory we can
-//! differentiate that from a file being deleted. This means the
-//! `Event::file_*`, such as [`Event::file_moved`], functions don't work. Only
-//! [`Event::modified`] will be triggered. Furthermore the events don't carry
-//! information about *which* file within a watched directory is affected.
-//!
-//! Events don't support [`Event::is_dir`].
+//! OpenBSD or macOS. Events for moving a file/directory into a watched a
+//! directory don't work ([`Event::file_moved_into`]), [`Event::file_created`]
+//! will be triggered.
 //!
 //! [`kqueue(2)`]: https://man.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
 //! [`setrlimit(2)`]: https://man.freebsd.org/cgi/man.cgi?query=setrlimit&sektion=2
@@ -191,13 +183,10 @@ new_flag!(
         #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "netbsd"))]
         OPEN = sys::INTEREST_OPEN,
         /// A file was moved out of the watched directory.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         MOVE_FROM = sys::INTEREST_MOVE_FROM,
         /// A file was moved into the watched directory.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         MOVE_INTO = sys::INTEREST_MOVE_INTO,
         /// A file was moved into or out of the watched directory.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         MOVE = sys::INTEREST_MOVE,
         /// File or directory was created in a watched directory.
         CREATE = sys::INTEREST_CREATE,
@@ -363,8 +352,7 @@ impl Event {
     // Getters for the events.
     bit_checks!(
         /// Return true if the subject of this event is a directory.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
-        is_dir, sys::EVENT_IS_DIR;
+        is_dir;
         /// Returns true if:
         ///  * the watched file was accessed, or
         ///  * a file within a watched directory was accessed.
@@ -439,24 +427,21 @@ impl Event {
 
         /// Returns true if:
         ///  * a file within a watched directory was moved out of the watched directory.
-        ///
-        /// This is not supported on kqueue (and will always return false) as it
-        /// can't differentiate between file moved out of the watched directory
-        /// and a file deleted.
         file_moved_from;
         /// Returns true if:
         ///  * a file within a watched directory was moved into the watched directory.
         ///
         /// This is not supported on kqueue (and will always return false) as it
         /// can't differentiate between file moved into the watched directory
-        /// and a file created.
+        /// and a new file created. When using this method also consider using
+        /// [`Event::file_created`] to ensure events are created for newly
+        /// created files.
         file_moved_into;
         /// Returns true if:
         ///  * a file within a watched directory was moved (into or of out of the watched directory).
         ///
-        /// This is not supported on kqueue (and will always return false) as it
-        /// can't differentiate between file moved into/out of the watched
-        /// directory and a file created/deleted.
+        /// The limitation documented in [`Event::file_moved_into`] also applies
+        /// here.
         file_moved;
         /// Returns true if:
         ///  * a file within a watched directory was created.

--- a/src/fs/notify.rs
+++ b/src/fs/notify.rs
@@ -419,7 +419,7 @@ impl Event {
         /// Returns true if:
         ///  * the watched file was deleted.
         ///  * the watched directory was deleted.
-        deleted, sys::EVENT_DELETED;
+        deleted;
         /// Returns true if:
         ///  * the watched file was moved.
         ///  * the watched directory was moved.
@@ -455,8 +455,7 @@ impl Event {
         file_created, sys::EVENT_FILE_CREATED;
         /// Returns true if:
         ///  * a file within a watched directory was deleted.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
-        file_deleted, sys::EVENT_FILE_DELETED;
+        file_deleted;
     );
 
     const fn mask(&self) -> u32 {

--- a/src/fs/notify.rs
+++ b/src/fs/notify.rs
@@ -196,8 +196,8 @@ new_flag!(
         /// A file was moved into the watched directory.
         #[cfg(any(target_os = "android", target_os = "linux"))]
         MOVE_INTO = sys::INTEREST_MOVE_INTO,
-        /// The watched file or directory itself was moved. Or a file was moved
-        /// into or out of the watched directory (`inotify` only).
+        /// A file was moved into or out of the watched directory.
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         MOVE = sys::INTEREST_MOVE,
         /// File or directory was created in a watched directory.
         CREATE = sys::INTEREST_CREATE,

--- a/src/fs/notify.rs
+++ b/src/fs/notify.rs
@@ -439,16 +439,25 @@ impl Event {
 
         /// Returns true if:
         ///  * a file within a watched directory was moved out of the watched directory.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
-        file_moved_from, sys::EVENT_FILE_MOVED_FROM;
+        ///
+        /// This is not supported on kqueue (and will always return false) as it
+        /// can't differentiate between file moved out of the watched directory
+        /// and a file deleted.
+        file_moved_from;
         /// Returns true if:
         ///  * a file within a watched directory was moved into the watched directory.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
-        file_moved_into, sys::EVENT_FILE_MOVED_INTO;
+        ///
+        /// This is not supported on kqueue (and will always return false) as it
+        /// can't differentiate between file moved into the watched directory
+        /// and a file created.
+        file_moved_into;
         /// Returns true if:
         ///  * a file within a watched directory was moved (into or of out of the watched directory).
-        #[cfg(any(target_os = "android", target_os = "linux"))]
-        file_moved, sys::EVENT_FILE_MOVED;
+        ///
+        /// This is not supported on kqueue (and will always return false) as it
+        /// can't differentiate between file moved into/out of the watched
+        /// directory and a file created/deleted.
+        file_moved;
         /// Returns true if:
         ///  * a file within a watched directory was created.
         ///

--- a/src/fs/notify.rs
+++ b/src/fs/notify.rs
@@ -190,6 +190,14 @@ new_flag!(
         /// A file was moved out of the watched directory.
         MOVE_FROM = sys::INTEREST_MOVE_FROM,
         /// A file was moved into the watched directory.
+        ///
+        /// # Notes
+        ///
+        /// This is not supported on kqueue as it can't differentiate between
+        /// file moved into the watched directory and a new file created.
+        /// Instead this will trigger events with [`Event::file_created`]
+        /// instead of [`Event::file_moved_into`]. Implementations should check
+        /// both methods.
         MOVE_INTO = sys::INTEREST_MOVE_INTO,
         /// A file was moved into or out of the watched directory.
         MOVE = sys::INTEREST_MOVE,
@@ -435,6 +443,8 @@ impl Event {
         file_moved_from;
         /// Returns true if:
         ///  * a file within a watched directory was moved into the watched directory.
+        ///
+        /// # Notes
         ///
         /// This is not supported on kqueue (and will always return false) as it
         /// can't differentiate between file moved into the watched directory

--- a/src/fs/notify.rs
+++ b/src/fs/notify.rs
@@ -467,12 +467,9 @@ impl Event {
 /// Macro to create functions to check bits set and include them in the
 /// fmt::Debug impl.
 macro_rules! bit_checks {
-    ( $( $(#[$meta: meta])* $fn_name: ident, $libc: ident :: $bit: ident ; )* ) => {
+    ( $( $(#[$meta: meta])* $fn_name: ident $(, $libc: ident :: $bit: ident)? ; )* ) => {
         $(
-        $( #[$meta] )*
-        pub fn $fn_name(&self) -> bool {
-            self.mask() & $libc::$bit != 0
-        }
+        $crate::fs::notify::bit_checks!(__fn $( #[$meta] )* $fn_name $(, $libc :: $bit )?);
         )*
 
         fn events(&self) -> impl fmt::Debug {
@@ -493,6 +490,18 @@ macro_rules! bit_checks {
             }
 
             Events(self)
+        }
+    };
+    (__fn $(#[$meta: meta])* $fn_name: ident) => {
+        $( #[$meta] )*
+        pub fn $fn_name(&self) -> bool {
+            self.0.$fn_name()
+        }
+    };
+    (__fn $(#[$meta: meta])* $fn_name: ident, $libc: ident :: $bit: ident ) => {
+        $( #[$meta] )*
+        pub fn $fn_name(&self) -> bool {
+            self.mask() & $libc::$bit != 0
         }
     };
 }

--- a/src/fs/notify.rs
+++ b/src/fs/notify.rs
@@ -62,6 +62,11 @@
 //! directory don't work ([`Event::file_moved_into`]), [`Event::file_created`]
 //! will be triggered.
 //!
+//! For events that set [`Event::file_created`] the following methods return
+//! incorrect results:
+//!  * [`Event::is_dir`] -- always true.
+//!  * [`Events::path_for`] -- only contains the parent directory.
+//!
 //! [`kqueue(2)`]: https://man.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
 //! [`setrlimit(2)`]: https://man.freebsd.org/cgi/man.cgi?query=setrlimit&sektion=2
 
@@ -451,7 +456,10 @@ impl Event {
         /// For the kqueue implementation the path returned is the directory,
         /// where as inotify returns the path of the file/directory that is
         /// created.
-        // TODO: fix the above.
+        ///
+        /// Furthermore, for the kqueue implementation if this returns true the
+        /// [`Event::is_dir`] method will also always return true, even if a
+        /// file was created.
         file_created;
         /// Returns true if:
         ///  * a file within a watched directory was deleted.

--- a/src/fs/notify.rs
+++ b/src/fs/notify.rs
@@ -373,7 +373,7 @@ impl Event {
         /// Returns true if:
         ///  * the watched file was modified, or
         ///  * a file within a watched directory was modified.
-        modified, sys::EVENT_MODIFIED;
+        modified;
         /// Returns true if:
         ///  * the watched file had its metadata (attributes) changed,
         ///  * a file within a watched directory had its metadata changed, or
@@ -451,8 +451,14 @@ impl Event {
         file_moved, sys::EVENT_FILE_MOVED;
         /// Returns true if:
         ///  * a file within a watched directory was created.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
-        file_created, sys::EVENT_FILE_CREATED;
+        ///
+        /// # Notes
+        ///
+        /// For the kqueue implementation the path returned is the directory,
+        /// where as inotify returns the path of the file/directory that is
+        /// created.
+        // TODO: fix the above.
+        file_created;
         /// Returns true if:
         ///  * a file within a watched directory was deleted.
         file_deleted;

--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -276,8 +276,16 @@ impl Event {
         self.event.mask
     }
 
+    pub(crate) fn modified(&self) -> bool {
+        self.mask() & EVENT_MODIFIED != 0
+    }
+
     pub(crate) fn deleted(&self) -> bool {
         self.mask() & EVENT_DELETED != 0
+    }
+
+    pub(crate) fn file_created(&self) -> bool {
+        self.mask() & EVENT_FILE_CREATED != 0
     }
 
     pub(crate) fn file_deleted(&self) -> bool {

--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -276,6 +276,14 @@ impl Event {
         self.event.mask
     }
 
+    pub(crate) fn deleted(&self) -> bool {
+        self.mask() & EVENT_DELETED != 0
+    }
+
+    pub(crate) fn file_deleted(&self) -> bool {
+        self.mask() & EVENT_FILE_DELETED != 0
+    }
+
     pub(crate) fn fmt<'a, 'b, 'f>(
         &self,
         f: &'f mut fmt::DebugStruct<'a, 'b>,

--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -284,6 +284,18 @@ impl Event {
         self.mask() & EVENT_DELETED != 0
     }
 
+    pub(crate) fn file_moved_from(&self) -> bool {
+        self.mask() & EVENT_FILE_MOVED_FROM != 0
+    }
+
+    pub(crate) fn file_moved_into(&self) -> bool {
+        self.mask() & EVENT_FILE_MOVED_INTO != 0
+    }
+
+    pub(crate) fn file_moved(&self) -> bool {
+        self.mask() & EVENT_FILE_MOVED != 0
+    }
+
     pub(crate) fn file_created(&self) -> bool {
         self.mask() & EVENT_FILE_CREATED != 0
     }

--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -276,6 +276,10 @@ impl Event {
         self.event.mask
     }
 
+    pub(crate) fn is_dir(&self) -> bool {
+        self.mask() & EVENT_IS_DIR != 0
+    }
+
     pub(crate) fn modified(&self) -> bool {
         self.mask() & EVENT_MODIFIED != 0
     }

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -293,10 +293,39 @@ impl<'a> FdIter for NotifyOp<'a> {
         (events, processed): &mut Self::Resources,
         (): &mut Self::Args,
     ) -> io::Result<Self::OperationOutput> {
-        if !events.is_empty() && events.len() > (*processed + 1) {
-            // Got another event ready to be processed, return it to the user.
-            *processed += 1;
-            return Ok(());
+        let prev_idx = *processed;
+        *processed += 1;
+        if events.len() > *processed {
+            let prev_event = &events[prev_idx];
+
+            // For deletion of a directory (not file) in a watched directory it
+            // will trigger two events, one for the child directory and one for
+            // the parent directory. To match with the inotify generated events
+            // we ignore the event for the parent directory.
+            if prev_event.mask() & EVENT_DELETED != 0
+                && let Some(parent) = prev_event.parent_fd()
+                && let Some(idx) = events[*processed..]
+                    .iter()
+                    .position(|e| e.0.ident == parent as _)
+            {
+                let next_event = &mut events[*processed + idx];
+                if next_event.mask() == EVENT_DIR_IN_DIR_DELETED {
+                    // The entire event only contain info about the deletion.
+                    if idx == 0 {
+                        *processed += 1; // Skip the event.
+                    } else {
+                        events.remove(*processed + idx); // Remove the event.
+                    }
+                } else {
+                    // Event contains more than just the deletion.
+                    next_event.0.fflags &= !EVENT_DIR_IN_DIR_DELETED;
+                }
+            }
+
+            if events.len() > *processed {
+                // Got another event ready to be processed, return it to the user.
+                return Ok(());
+            }
         }
 
         // No blocking.
@@ -356,6 +385,22 @@ impl Event {
         let fd = (self.0.udata as isize) >> 32;
         if fd == 0 { None } else { Some(fd as RawFd) }
     }
+
+    pub(crate) fn deleted(&self) -> bool {
+        if self.parent_fd().is_some() {
+            false
+        } else {
+            self.mask() & EVENT_DELETED != 0
+        }
+    }
+
+    pub(crate) fn file_deleted(&self) -> bool {
+        if self.parent_fd().is_some() {
+            self.mask() & EVENT_FILE_DELETED != 0
+        } else {
+            false
+        }
+    }
 }
 
 #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
@@ -376,3 +421,5 @@ pub(crate) const EVENT_OPENED: u32 = libc::NOTE_OPEN;
 pub(crate) const EVENT_DELETED: u32 = libc::NOTE_DELETE;
 pub(crate) const EVENT_MOVED: u32 = libc::NOTE_RENAME;
 pub(crate) const EVENT_UNMOUNTED: u32 = libc::NOTE_REVOKE;
+pub(crate) const EVENT_FILE_DELETED: u32 = libc::NOTE_DELETE | libc::NOTE_LINK;
+const EVENT_DIR_IN_DIR_DELETED: u32 = libc::NOTE_WRITE | libc::NOTE_LINK;

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -245,15 +245,14 @@ pub(crate) const INTEREST_MOVE_SELF: u32 = libc::NOTE_RENAME;
 
 #[derive(Debug)]
 pub(crate) struct EventsState<'w> {
-    state: kqueue::op::State<Evented, Event, ()>,
+    state: kqueue::op::State<Evented, (Vec<Event>, usize), ()>,
     _unused: PhantomData<&'w ()>,
 }
 
 impl<'w> EventsState<'w> {
     pub(crate) fn new(_: &'w AsyncFd) -> EventsState<'w> {
         EventsState {
-            // SAFETY: all zeros is valid for `libc::kevent`.
-            state: kqueue::op::State::new(Event(unsafe { mem::zeroed() }), ()),
+            state: kqueue::op::State::new((Vec::with_capacity(8), 0), ()),
             _unused: PhantomData,
         }
     }
@@ -289,7 +288,7 @@ pub(crate) struct NotifyOp<'a>(PhantomData<&'a ()>);
 
 impl<'a> FdIter for NotifyOp<'a> {
     type Output = &'a notify::Event;
-    type Resources = Event;
+    type Resources = (Vec<Event>, usize);
     type Args = ();
     type OperationOutput = ();
 
@@ -297,9 +296,15 @@ impl<'a> FdIter for NotifyOp<'a> {
 
     fn try_run(
         kq: &AsyncFd,
-        event: &mut Self::Resources,
+        (events, processed): &mut Self::Resources,
         (): &mut Self::Args,
     ) -> io::Result<Self::OperationOutput> {
+        if !events.is_empty() && events.len() > (*processed + 1) {
+            // Got another event ready to be processed, return it to the user.
+            *processed += 1;
+            return Ok(());
+        }
+
         // No blocking.
         let timeout = libc::timespec {
             tv_sec: 0,
@@ -309,16 +314,16 @@ impl<'a> FdIter for NotifyOp<'a> {
             kq.fd(),
             ptr::null(),
             0,
-            &raw mut event.0,
-            1,
+            events.as_mut_ptr().cast::<libc::kevent>(),
+            events.capacity() as _,
             &raw const timeout,
         ))?;
         if n == 0 {
             // Wait for another readiness event.
             Err(io::ErrorKind::WouldBlock.into())
         } else {
-            debug_assert!(n == 1);
-            debug_assert_eq!(event.0.filter, libc::EVFILT_VNODE);
+            unsafe { events.set_len(n as _) };
+            *processed = 0;
             Ok(())
         }
     }
@@ -327,7 +332,13 @@ impl<'a> FdIter for NotifyOp<'a> {
         false
     }
 
-    fn map_next(_: &AsyncFd, event: &Self::Resources, (): Self::OperationOutput) -> Self::Output {
+    fn map_next(
+        _: &AsyncFd,
+        (events, processed): &Self::Resources,
+        (): Self::OperationOutput,
+    ) -> Self::Output {
+        let event = &events[*processed];
+        debug_assert_eq!(event.0.filter, libc::EVFILT_VNODE);
         // SAFETY: cast is safe due to repr(transparent) on notify::Event.
         unsafe { &*ptr::from_ref(event).cast::<notify::Event>() }
     }

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -110,6 +110,7 @@ pub(crate) fn watch(
     watch_path(kq, watching, path, interest, recursive, false, None, None)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn watch_path(
     kq: &AsyncFd,
     watching: &mut Watching,
@@ -183,6 +184,7 @@ fn watch_fd(
     } else {
         0
     };
+    #[allow(clippy::cast_sign_loss)] // fd are never negative.
     if let Some(fd) = parent {
         udata |= (fd as usize) << 32;
     }
@@ -355,6 +357,7 @@ impl<'a> FdIter for NotifyOp<'a> {
 
     const OP_KIND: OpKind = OpKind::Read;
 
+    #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     fn try_run(
         kq: &AsyncFd,
         (events, processed): &mut Self::Resources,
@@ -404,10 +407,10 @@ impl<'a> FdIter for NotifyOp<'a> {
                         // directory we get two events with the following flags:
                         // [0] NOTE_WRITE   on the watched directory.
                         // [1] NOTE_RENAME  on the moved file/directory.
-                        drop(events.remove(i)); // Remove the event for the directory.
+                        _ = events.remove(i); // Remove the event for the directory.
                         let event = &mut events[i + idx];
                         event.0.udata =
-                            (event.0.udata as u64 | EVENT_EXTRA_FILE_MOVED_FROM as u64) as _;
+                            (event.0.udata as u64 | u64::from(EVENT_EXTRA_FILE_MOVED_FROM)) as _;
                         event.0.fflags &= !libc::NOTE_RENAME; // Don't trigger Event::moved.
                         continue; // NOTE: don't increment i as we've removed an event.
                     } else if head.iter().any(|e| {
@@ -426,7 +429,7 @@ impl<'a> FdIter for NotifyOp<'a> {
                         //
                         // In this case we remove the event for the directory,
                         // the deletion event doesn't have to be modified.
-                        drop(events.remove(i)); // Remove the event for the directory.
+                        _ = events.remove(i); // Remove the event for the directory.
                     } else {
                         // When a file/directory is create in a watched
                         // directory we get one event with the following flags:
@@ -434,7 +437,7 @@ impl<'a> FdIter for NotifyOp<'a> {
                         let event = &mut head[i];
                         event.0.fflags &= !libc::NOTE_WRITE; // Don't trigger Event::modified.
                         event.0.udata =
-                            (event.0.udata as u64 | EVENT_EXTRA_FILE_CREATED as u64) as _;
+                            (event.0.udata as u64 | u64::from(EVENT_EXTRA_FILE_CREATED)) as _;
                         // TODO: get the path of the new file/directory.
                         // TODO: determine if the new file is a file or
                         // directory and set EVENT_EXTRA_IS_DIR.
@@ -505,6 +508,7 @@ impl Event {
         self.mask_extra() & EVENT_EXTRA_FILE_MOVED_FROM != 0
     }
 
+    #[allow(clippy::unused_self)]
     pub(crate) fn file_moved_into(&self) -> bool {
         false // Not supported.
     }

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -214,7 +214,6 @@ pub(crate) const INTEREST_ALL: u32 = INTEREST_ACCESS
     | INTEREST_METADATA
     | INTEREST_CLOSE
     | INTEREST_OPEN
-    | INTEREST_MOVE
     | INTEREST_CREATE
     | INTEREST_DELETE
     | INTEREST_DELETE_SELF
@@ -237,7 +236,6 @@ const INTEREST_CLOSE: u32 = 0; // Not supported.
 pub(crate) const INTEREST_OPEN: u32 = libc::NOTE_OPEN;
 #[cfg(not(any(target_os = "freebsd", target_os = "netbsd")))]
 const INTEREST_OPEN: u32 = 0; // Not supported.
-pub(crate) const INTEREST_MOVE: u32 = libc::NOTE_RENAME;
 pub(crate) const INTEREST_CREATE: u32 = libc::NOTE_WRITE;
 pub(crate) const INTEREST_DELETE: u32 = libc::NOTE_DELETE | libc::NOTE_LINK;
 pub(crate) const INTEREST_DELETE_SELF: u32 = libc::NOTE_DELETE;

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -13,7 +13,7 @@ use std::{fmt, io, mem, ptr};
 
 use crate::fs::notify::{self, Events, Interest, Recursive, Watcher};
 use crate::kqueue::fd::OpKind;
-use crate::kqueue::op::{Evented, FdIter};
+use crate::kqueue::op::FdIter;
 use crate::kqueue::{self, kqueue};
 use crate::op::{FdIter as _, OpState};
 use crate::{AsyncFd, SubmissionQueue, syscall};
@@ -244,17 +244,11 @@ pub(crate) const INTEREST_DELETE_SELF: u32 = libc::NOTE_DELETE;
 pub(crate) const INTEREST_MOVE_SELF: u32 = libc::NOTE_RENAME;
 
 #[derive(Debug)]
-pub(crate) struct EventsState<'w> {
-    state: kqueue::op::State<Evented, (Vec<Event>, usize), ()>,
-    _unused: PhantomData<&'w ()>,
-}
+pub(crate) struct EventsState<'w>(<NotifyOp<'w> as crate::op::FdIter>::State);
 
 impl<'w> EventsState<'w> {
     pub(crate) fn new(_: &'w AsyncFd) -> EventsState<'w> {
-        EventsState {
-            state: kqueue::op::State::new((Vec::with_capacity(8), 0), ()),
-            _unused: PhantomData,
-        }
+        EventsState(kqueue::op::State::new((Vec::with_capacity(8), 0), ()))
     }
 }
 
@@ -277,7 +271,7 @@ impl<'w> Events<'w> {
     ) -> Poll<Option<io::Result<&'w notify::Event>>> {
         let Events {
             fd: kq,
-            state: EventsState { state, .. },
+            state: EventsState(state),
             ..
         } = &mut *self;
         NotifyOp::poll_next(state, ctx, kq)

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -400,6 +400,18 @@ impl Event {
         }
     }
 
+    pub(crate) fn file_moved_from(&self) -> bool {
+        false // Not supported.
+    }
+
+    pub(crate) fn file_moved_into(&self) -> bool {
+        false // Not supported.
+    }
+
+    pub(crate) fn file_moved(&self) -> bool {
+        false // Not supported.
+    }
+
     pub(crate) fn file_created(&self) -> bool {
         if self.is_dir() {
             self.mask() & EVENT_FILE_CREATED != 0

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -97,27 +97,7 @@ pub(crate) fn watch_recursive(
     recursive: Recursive,
     dir_only: bool,
 ) -> io::Result<()> {
-    match std::fs::read_dir(&dir) {
-        Ok(read_dir) => {
-            for result in read_dir {
-                let entry = result?;
-                let path = entry.path();
-                if let Recursive::All = recursive
-                    && entry.file_type()?.is_dir()
-                {
-                    watch_recursive(kq, watching, path, interest, Recursive::All, true)?;
-                } else {
-                    watch_path(kq, watching, path, interest)?;
-                }
-            }
-        }
-        Err(ref err) if !dir_only && err.kind() == io::ErrorKind::NotADirectory => {
-            // Ignore the error.
-        }
-        Err(err) => return Err(err),
-    }
-
-    watch_path(kq, watching, dir, interest)
+    watch_path(kq, watching, dir, interest, recursive, dir_only, None, None)
 }
 
 pub(crate) fn watch(
@@ -126,9 +106,8 @@ pub(crate) fn watch(
     path: PathBuf,
     interest: Interest,
 ) -> io::Result<()> {
-    // To minic inotify we need to watch all files and directories within a
-    // watched directory, so we use watch_recursive to do that for us.
-    watch_recursive(kq, watching, path, interest, Recursive::No, false)
+    let recursive = Recursive::No;
+    watch_path(kq, watching, path, interest, recursive, false, None, None)
 }
 
 fn watch_path(
@@ -136,15 +115,78 @@ fn watch_path(
     watching: &mut Watching,
     path: PathBuf,
     interest: Interest,
+    recursive: Recursive,
+    dir_only: bool,
+    is_dir: Option<bool>,
+    parent: Option<RawFd>,
 ) -> io::Result<()> {
+    // To minic inotify we need to watch all files and directories within a
+    // watched directory.
+
     let path =
         unsafe { PathBufWithNull::from_vec_unchecked(OsString::from(path).into_encoded_bytes()) };
     let fd = WatchedFd::open(&path)?;
+
+    let is_dir = if let Some(false) = is_dir {
+        false
+    } else {
+        let path = unsafe { Path::new(OsStr::from_encoded_bytes_unchecked(path.as_bytes())) };
+        let parent = fd.0.as_raw_fd();
+        match std::fs::read_dir(path) {
+            Ok(read_dir) => {
+                for result in read_dir {
+                    let entry = result?;
+                    let path = entry.path();
+                    let is_dir = entry.file_type()?.is_dir();
+                    watch_path(
+                        kq,
+                        watching,
+                        path,
+                        interest,
+                        recursive,
+                        false, // dir_only is only for parent dir, so set to false.
+                        Some(is_dir),
+                        Some(parent),
+                    )?;
+                }
+                true // Is a directory.
+            }
+            Err(ref err) if !dir_only && err.kind() == io::ErrorKind::NotADirectory => {
+                // Ignore the error.
+                false // Not a directory.
+            }
+            Err(err) => return Err(err),
+        }
+    };
+
+    watch_fd(kq, watching, fd, path, interest, is_dir, parent)
+}
+
+fn watch_fd(
+    kq: &AsyncFd,
+    watching: &mut Watching,
+    fd: WatchedFd,
+    path: PathBufWithNull,
+    interest: Interest,
+    is_dir: bool,
+    parent: Option<RawFd>,
+) -> io::Result<()> {
+    // User data passed to decode the events:
+    // * lowest 1 bit indicates if the fd is a directory.
+    // * the upper 32 bits, excluding the sign bit, represent the parent fd. Or
+    //   zero if the root of the watched path.
+    let mut udata: isize = if is_dir { 1 } else { 0 };
+    if let Some(fd) = parent {
+        udata |= (fd as isize) << 32;
+    }
+
+    //dbg!(&fd, &path, &is_dir, &parent, &udata);
     let change = Event(libc::kevent {
         ident: fd.0.as_raw_fd().cast_unsigned() as _,
         filter: libc::EVFILT_VNODE,
         flags: libc::EV_ADD | libc::EV_CLEAR,
         fflags: interest.0,
+        udata: udata as _,
         // SAFETY: all zeros is valid for `kevent`.
         ..unsafe { mem::zeroed() }
     });
@@ -160,6 +202,7 @@ fn watch_path(
         0,
         ptr::null(),
     ))?;
+
     // NOTE: it's possible the `wd` is already watched, we'll overwrite the
     // path, the watched interested is combined (within the kernel).
     _ = watching.insert(fd, path);
@@ -302,6 +345,15 @@ impl Event {
 
     pub(crate) const fn mask(&self) -> u32 {
         self.0.fflags
+    }
+
+    pub(crate) fn is_dir(&self) -> bool {
+        (self.0.udata as isize) & 0b1 == 1
+    }
+
+    pub(crate) fn parent_fd(&self) -> Option<RawFd> {
+        let fd = (self.0.udata as isize) >> 32;
+        if fd == 0 { None } else { Some(fd as RawFd) }
     }
 }
 

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -11,6 +11,7 @@ use std::pin::Pin;
 use std::task::{self, Poll};
 use std::{fmt, io, mem, ptr};
 
+use crate::fs::Metadata;
 use crate::fs::notify::{self, Events, Interest, Recursive, Watcher};
 use crate::kqueue::fd::OpKind;
 use crate::kqueue::op::FdIter;
@@ -130,6 +131,16 @@ fn watch_path(
 
     let is_dir = if let Some(false) = is_dir {
         false
+    } else if parent.is_some()
+        && let Recursive::No = recursive
+    {
+        // We need to watch all files inside of a watched directory regardless
+        // of the recursion requested. If recursion is not requested and the
+        // parent is some we stop here.
+        // SAFETY: fully zeroed `libc::stat` is valid.
+        let mut metadata: Metadata = unsafe { mem::zeroed() };
+        syscall!(fstat(fd.0.as_raw_fd(), &raw mut metadata.0))?;
+        metadata.is_dir()
     } else {
         let path = unsafe { Path::new(OsStr::from_encoded_bytes_unchecked(path.as_bytes())) };
         let parent = fd.0.as_raw_fd();

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -238,7 +238,7 @@ pub(crate) const INTEREST_OPEN: u32 = libc::NOTE_OPEN;
 #[cfg(not(any(target_os = "freebsd", target_os = "netbsd")))]
 const INTEREST_OPEN: u32 = 0; // Not supported.
 pub(crate) const INTEREST_MOVE: u32 = libc::NOTE_RENAME;
-pub(crate) const INTEREST_CREATE: u32 = libc::NOTE_EXTEND;
+pub(crate) const INTEREST_CREATE: u32 = libc::NOTE_WRITE;
 pub(crate) const INTEREST_DELETE: u32 = libc::NOTE_DELETE | libc::NOTE_LINK;
 pub(crate) const INTEREST_DELETE_SELF: u32 = libc::NOTE_DELETE;
 pub(crate) const INTEREST_MOVE_SELF: u32 = libc::NOTE_RENAME;
@@ -386,11 +386,27 @@ impl Event {
         if fd == 0 { None } else { Some(fd as RawFd) }
     }
 
+    pub(crate) fn modified(&self) -> bool {
+        if self.is_dir() {
+            false // File changes are returned via the events on the file watch.
+        } else {
+            self.mask() & EVENT_MODIFIED != 0
+        }
+    }
+
     pub(crate) fn deleted(&self) -> bool {
         if self.parent_fd().is_some() {
             false
         } else {
             self.mask() & EVENT_DELETED != 0
+        }
+    }
+
+    pub(crate) fn file_created(&self) -> bool {
+        if self.is_dir() {
+            self.mask() & EVENT_FILE_CREATED != 0
+        } else {
+            false
         }
     }
 
@@ -421,5 +437,6 @@ pub(crate) const EVENT_OPENED: u32 = libc::NOTE_OPEN;
 pub(crate) const EVENT_DELETED: u32 = libc::NOTE_DELETE;
 pub(crate) const EVENT_MOVED: u32 = libc::NOTE_RENAME;
 pub(crate) const EVENT_UNMOUNTED: u32 = libc::NOTE_REVOKE;
+pub(crate) const EVENT_FILE_CREATED: u32 = libc::NOTE_WRITE;
 pub(crate) const EVENT_FILE_DELETED: u32 = libc::NOTE_DELETE | libc::NOTE_LINK;
 const EVENT_DIR_IN_DIR_DELETED: u32 = libc::NOTE_WRITE | libc::NOTE_LINK;

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -433,9 +433,8 @@ impl<'a> FdIter for NotifyOp<'a> {
                         // [0] NOTE_WRITE   on the watched directory.
                         let event = &mut head[i];
                         event.0.fflags &= !libc::NOTE_WRITE; // Don't trigger Event::modified.
-                        event.0.udata = ((event.0.udata as u64 | EVENT_EXTRA_FILE_CREATED as u64)
-                            & !EVENT_EXTRA_IS_DIR as u64)
-                            as _;
+                        event.0.udata =
+                            (event.0.udata as u64 | EVENT_EXTRA_FILE_CREATED as u64) as _;
                         // TODO: get the path of the new file/directory.
                         // TODO: determine if the new file is a file or
                         // directory and set EVENT_EXTRA_IS_DIR.

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -172,20 +172,95 @@ fn watch_fd(
     parent: Option<RawFd>,
 ) -> io::Result<()> {
     // User data passed to decode the events:
-    // * lowest 1 bit indicates if the fd is a directory.
+    // * the lower 32 bits are used to create additional event data from
+    //   multiple events, see the EVENT_EXTRA_* constants.
+    //   The first bit we set here, which is an indication if the fd is a file
+    //   or directory.
     // * the upper 32 bits, excluding the sign bit, represent the parent fd. Or
     //   zero if the root of the watched path.
-    let mut udata: isize = if is_dir { 1 } else { 0 };
+    let mut udata: usize = if is_dir {
+        EVENT_EXTRA_IS_DIR as usize
+    } else {
+        0
+    };
     if let Some(fd) = parent {
-        udata |= (fd as isize) << 32;
+        udata |= (fd as usize) << 32;
     }
 
-    //dbg!(&fd, &path, &is_dir, &parent, &udata);
+    // Map the interest to the correct fflags.
+    let mut flags = 0;
+    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+    if interest.0 & INTEREST_ACCESS != 0 {
+        flags |= libc::NOTE_READ;
+    }
+    if interest.0 & INTEREST_MODIFY != 0 {
+        flags |= libc::NOTE_WRITE | libc::NOTE_EXTEND;
+        #[cfg(target_os = "openbsd")]
+        {
+            flags |= libc::NOTE_TRUNCATE;
+        }
+    }
+    if interest.0 & INTEREST_METADATA != 0 {
+        flags |= libc::NOTE_ATTRIB;
+    }
+    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+    if interest.0 & INTEREST_CLOSE_WRITE != 0 {
+        flags |= libc::NOTE_CLOSE_WRITE;
+    }
+    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+    if interest.0 & INTEREST_CLOSE_NOWRITE != 0 {
+        flags |= libc::NOTE_CLOSE;
+    }
+    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+    if interest.0 & INTEREST_OPEN != 0 {
+        flags |= libc::NOTE_OPEN;
+    }
+    if interest.0 & INTEREST_MOVE_INTO != 0 {
+        // We can't determine if a file/directory is created or moved into a
+        // watched directory, kqueue simply doesn't give us enough information.
+        // Best we can do it trigger an event that a file/directory is created.
+        flags |= libc::NOTE_WRITE;
+    }
+    if interest.0 & INTEREST_MOVE_FROM != 0 {
+        // When a file/directory is moved we get two events with the following
+        // flags:
+        // [0] NOTE_WRITE   on watched directory.
+        // [1] NOTE_RENAME  on moved file/directory.
+        if is_dir {
+            flags |= libc::NOTE_WRITE;
+        }
+        if parent.is_some() {
+            flags |= libc::NOTE_RENAME;
+        }
+    }
+    if interest.0 & INTEREST_CREATE != 0 && is_dir {
+        // When a file/directory is created we only get one event:
+        // [0] NOTE_WRITE   on watched directory.
+        //
+        // Since we aren't watching the newly created we don't know what file is
+        // actually created.
+        flags |= libc::NOTE_WRITE;
+    }
+    if interest.0 & INTEREST_DELETE != 0 && parent.is_some() {
+        // On each file file inside a watched directory watch for deletion events.
+        flags |= libc::NOTE_DELETE;
+    }
+    if parent.is_none() {
+        // The *_SELF interests only apply to the fd that watch was called on,
+        // so if the fd has a parent ignore it.
+        if interest.0 & INTEREST_DELETE_SELF != 0 {
+            flags |= libc::NOTE_DELETE;
+        }
+        if interest.0 & INTEREST_MOVE_SELF != 0 {
+            flags |= libc::NOTE_RENAME;
+        }
+    }
+
     let change = Event(libc::kevent {
         ident: fd.0.as_raw_fd().cast_unsigned() as _,
         filter: libc::EVFILT_VNODE,
         flags: libc::EV_ADD | libc::EV_CLEAR,
-        fflags: interest.0,
+        fflags: flags,
         udata: udata as _,
         // SAFETY: all zeros is valid for `kevent`.
         ..unsafe { mem::zeroed() }
@@ -209,37 +284,31 @@ fn watch_fd(
     Ok(())
 }
 
+// Custom bitset, mapped in `watch_fd`.
 pub(crate) const INTEREST_ALL: u32 = INTEREST_ACCESS
     | INTEREST_MODIFY
     | INTEREST_METADATA
     | INTEREST_CLOSE
     | INTEREST_OPEN
+    | INTEREST_MOVE
     | INTEREST_CREATE
     | INTEREST_DELETE
     | INTEREST_DELETE_SELF
     | INTEREST_MOVE_SELF;
-#[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
-pub(crate) const INTEREST_ACCESS: u32 = libc::NOTE_READ;
-#[cfg(not(any(target_os = "freebsd", target_os = "netbsd")))]
-const INTEREST_ACCESS: u32 = 0; // Not supported.
-pub(crate) const INTEREST_MODIFY: u32 = libc::NOTE_WRITE;
-pub(crate) const INTEREST_METADATA: u32 = libc::NOTE_ATTRIB;
-#[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
-pub(crate) const INTEREST_CLOSE_WRITE: u32 = libc::NOTE_CLOSE_WRITE;
-#[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
-pub(crate) const INTEREST_CLOSE_NOWRITE: u32 = libc::NOTE_CLOSE;
-#[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+pub(crate) const INTEREST_ACCESS: u32 = 1 << 0;
+pub(crate) const INTEREST_MODIFY: u32 = 1 << 1;
+pub(crate) const INTEREST_METADATA: u32 = 1 << 2;
+pub(crate) const INTEREST_CLOSE_WRITE: u32 = 1 << 3;
+pub(crate) const INTEREST_CLOSE_NOWRITE: u32 = 1 << 4;
 pub(crate) const INTEREST_CLOSE: u32 = INTEREST_CLOSE_WRITE | INTEREST_CLOSE_NOWRITE;
-#[cfg(not(any(target_os = "freebsd", target_os = "netbsd")))]
-const INTEREST_CLOSE: u32 = 0; // Not supported.
-#[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
-pub(crate) const INTEREST_OPEN: u32 = libc::NOTE_OPEN;
-#[cfg(not(any(target_os = "freebsd", target_os = "netbsd")))]
-const INTEREST_OPEN: u32 = 0; // Not supported.
-pub(crate) const INTEREST_CREATE: u32 = libc::NOTE_WRITE;
-pub(crate) const INTEREST_DELETE: u32 = libc::NOTE_DELETE | libc::NOTE_LINK;
-pub(crate) const INTEREST_DELETE_SELF: u32 = libc::NOTE_DELETE;
-pub(crate) const INTEREST_MOVE_SELF: u32 = libc::NOTE_RENAME;
+pub(crate) const INTEREST_OPEN: u32 = 1 << 5;
+pub(crate) const INTEREST_MOVE_INTO: u32 = 1 << 6;
+pub(crate) const INTEREST_MOVE_FROM: u32 = 1 << 7;
+pub(crate) const INTEREST_MOVE: u32 = INTEREST_MOVE_INTO | INTEREST_MOVE_FROM;
+pub(crate) const INTEREST_CREATE: u32 = 1 << 8;
+pub(crate) const INTEREST_DELETE: u32 = 1 << 9;
+pub(crate) const INTEREST_DELETE_SELF: u32 = 1 << 10;
+pub(crate) const INTEREST_MOVE_SELF: u32 = 1 << 11;
 
 #[derive(Debug)]
 pub(crate) struct EventsState<'w>(<NotifyOp<'w> as crate::op::FdIter>::State);
@@ -291,39 +360,10 @@ impl<'a> FdIter for NotifyOp<'a> {
         (events, processed): &mut Self::Resources,
         (): &mut Self::Args,
     ) -> io::Result<Self::OperationOutput> {
-        let prev_idx = *processed;
         *processed += 1;
         if events.len() > *processed {
-            let prev_event = &events[prev_idx];
-
-            // For deletion of a directory (not file) in a watched directory it
-            // will trigger two events, one for the child directory and one for
-            // the parent directory. To match with the inotify generated events
-            // we ignore the event for the parent directory.
-            if prev_event.mask() & EVENT_DELETED != 0
-                && let Some(parent) = prev_event.parent_fd()
-                && let Some(idx) = events[*processed..]
-                    .iter()
-                    .position(|e| e.0.ident == parent as _)
-            {
-                let next_event = &mut events[*processed + idx];
-                if next_event.mask() == EVENT_DIR_IN_DIR_DELETED {
-                    // The entire event only contain info about the deletion.
-                    if idx == 0 {
-                        *processed += 1; // Skip the event.
-                    } else {
-                        events.remove(*processed + idx); // Remove the event.
-                    }
-                } else {
-                    // Event contains more than just the deletion.
-                    next_event.0.fflags &= !EVENT_DIR_IN_DIR_DELETED;
-                }
-            }
-
-            if events.len() > *processed {
-                // Got another event ready to be processed, return it to the user.
-                return Ok(());
-            }
+            // Got another event ready to be processed, return it to the user.
+            return Ok(());
         }
 
         // No blocking.
@@ -345,6 +385,64 @@ impl<'a> FdIter for NotifyOp<'a> {
         } else {
             unsafe { events.set_len(n as _) };
             *processed = 0;
+            log::trace!(events:?; "got fs events");
+            let mut i = 0;
+            while let Some((head, tail)) = events.split_at_mut_checked(i + 1) {
+                let event = &head[i];
+
+                if event.is_dir() && (event.0.fflags & libc::NOTE_WRITE != 0) {
+                    // NOTE_WRITE on a directory means *something* happened
+                    // within the directory, e.g. a file/directory was created
+                    // or deleted. But kqueue doesn't tell us what, so we have
+                    // to figure that out here.
+
+                    if let Some(idx) = tail.iter().position(|e| {
+                        e.parent_fd() == Some(event.0.ident as _)
+                            && e.0.fflags & libc::NOTE_RENAME != 0
+                    }) {
+                        // When a file/directory is moved out of a watched
+                        // directory we get two events with the following flags:
+                        // [0] NOTE_WRITE   on the watched directory.
+                        // [1] NOTE_RENAME  on the moved file/directory.
+                        drop(events.remove(i)); // Remove the event for the directory.
+                        let event = &mut events[i + idx];
+                        event.0.udata =
+                            (event.0.udata as u64 | EVENT_EXTRA_FILE_MOVED_FROM as u64) as _;
+                        event.0.fflags &= !libc::NOTE_RENAME; // Don't trigger Event::moved.
+                        continue; // NOTE: don't increment i as we've removed an event.
+                    } else if head.iter().any(|e| {
+                        e.parent_fd() == Some(event.0.ident as _)
+                            && e.0.fflags & libc::NOTE_DELETE != 0
+                    }) {
+                        // When Interest::DELETE is used alone we get a single
+                        // event:
+                        // [0] NOTE_DELETE  on the deleted file/directory.
+                        //
+                        // We don't get an event for the directory. However,
+                        // when used in combination with CREATE or MOVE_FROM it
+                        // will trigger a second event:
+                        // [0] NOTE_DELETE  on the deleted file/directory.
+                        // [1] NOTE_WRITE   on the watched directory.
+                        //
+                        // In this case we remove the event for the directory,
+                        // the deletion event doesn't have to be modified.
+                        drop(events.remove(i)); // Remove the event for the directory.
+                    } else {
+                        // When a file/directory is create in a watched
+                        // directory we get one event with the following flags:
+                        // [0] NOTE_WRITE   on the watched directory.
+                        let event = &mut head[i];
+                        event.0.fflags &= !libc::NOTE_WRITE; // Don't trigger Event::modified.
+                        event.0.udata = ((event.0.udata as u64 | EVENT_EXTRA_FILE_CREATED as u64)
+                            & !EVENT_EXTRA_IS_DIR as u64)
+                            as _;
+                        // TODO: get the path of the new file/directory.
+                        // TODO: determine if the new file is a file or
+                        // directory and set EVENT_EXTRA_IS_DIR.
+                    }
+                }
+                i += 1;
+            }
             Ok(())
         }
     }
@@ -375,13 +473,17 @@ impl Event {
         self.0.fflags
     }
 
-    pub(crate) fn is_dir(&self) -> bool {
-        (self.0.udata as isize) & 0b1 == 1
-    }
-
-    pub(crate) fn parent_fd(&self) -> Option<RawFd> {
+    fn parent_fd(&self) -> Option<RawFd> {
         let fd = (self.0.udata as isize) >> 32;
         if fd == 0 { None } else { Some(fd as RawFd) }
+    }
+
+    fn mask_extra(&self) -> u32 {
+        ((self.0.udata as usize) & !((u32::MAX as usize) << 32)) as u32
+    }
+
+    pub(crate) fn is_dir(&self) -> bool {
+        self.mask_extra() & EVENT_EXTRA_IS_DIR != 0
     }
 
     pub(crate) fn modified(&self) -> bool {
@@ -396,12 +498,12 @@ impl Event {
         if self.parent_fd().is_some() {
             false
         } else {
-            self.mask() & EVENT_DELETED != 0
+            self.mask() & libc::NOTE_DELETE != 0
         }
     }
 
     pub(crate) fn file_moved_from(&self) -> bool {
-        false // Not supported.
+        self.mask_extra() & EVENT_EXTRA_FILE_MOVED_FROM != 0
     }
 
     pub(crate) fn file_moved_into(&self) -> bool {
@@ -409,20 +511,16 @@ impl Event {
     }
 
     pub(crate) fn file_moved(&self) -> bool {
-        false // Not supported.
+        self.mask_extra() & EVENT_EXTRA_FILE_MOVED != 0
     }
 
     pub(crate) fn file_created(&self) -> bool {
-        if self.is_dir() {
-            self.mask() & EVENT_FILE_CREATED != 0
-        } else {
-            false
-        }
+        self.mask_extra() & EVENT_EXTRA_FILE_CREATED != 0
     }
 
     pub(crate) fn file_deleted(&self) -> bool {
         if self.parent_fd().is_some() {
-            self.mask() & EVENT_FILE_DELETED != 0
+            self.mask() & libc::NOTE_DELETE != 0
         } else {
             false
         }
@@ -444,9 +542,10 @@ pub(crate) const EVENT_CLOSED_NO_WRITE: u32 = libc::NOTE_CLOSE;
 pub(crate) const EVENT_CLOSED: u32 = libc::NOTE_CLOSE_WRITE | libc::NOTE_CLOSE;
 #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
 pub(crate) const EVENT_OPENED: u32 = libc::NOTE_OPEN;
-pub(crate) const EVENT_DELETED: u32 = libc::NOTE_DELETE;
 pub(crate) const EVENT_MOVED: u32 = libc::NOTE_RENAME;
 pub(crate) const EVENT_UNMOUNTED: u32 = libc::NOTE_REVOKE;
-pub(crate) const EVENT_FILE_CREATED: u32 = libc::NOTE_WRITE;
-pub(crate) const EVENT_FILE_DELETED: u32 = libc::NOTE_DELETE | libc::NOTE_LINK;
-const EVENT_DIR_IN_DIR_DELETED: u32 = libc::NOTE_WRITE | libc::NOTE_LINK;
+
+const EVENT_EXTRA_IS_DIR: u32 = 1 << 0; // NOTE: set on registering the event.
+const EVENT_EXTRA_FILE_MOVED_FROM: u32 = 1 << 1;
+const EVENT_EXTRA_FILE_MOVED: u32 = EVENT_EXTRA_FILE_MOVED_FROM;
+const EVENT_EXTRA_FILE_CREATED: u32 = 1 << 3;

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -328,10 +328,6 @@ impl<'a> FdIter for NotifyOp<'a> {
         }
     }
 
-    fn is_complete((): &Self::OperationOutput) -> bool {
-        false
-    }
-
     fn map_next(
         _: &AsyncFd,
         (events, processed): &Self::Resources,

--- a/src/kqueue/op.rs
+++ b/src/kqueue/op.rs
@@ -480,7 +480,9 @@ impl<T: FdIter> crate::op::FdIter for T {
                     let resources = unsafe { state.resources.assume_init_read() };
                     r.insert(resources)
                 } else {
-                    state.status = Evented::ToSubmit;
+                    // Need to try the operation again and hit a would block
+                    // error before we can wait for another readiness event.
+                    state.status = Evented::Waiting;
                     // SAFETY: the old status was not Complete, which means that the
                     // resources are initialised, so we can safely return a
                     // reference to it.

--- a/tests/functional/fs_notify.rs
+++ b/tests/functional/fs_notify.rs
@@ -47,7 +47,7 @@ fn watched_directory_file_created() {
         },
         |path, ()| {
             vec![ExpectEvent {
-                full_path: path.clone(),
+                full_path: kqueue_path_file_created_workaround(path),
                 file_path: FILE_NAME,
                 file_created: true,
                 ..Default::default()
@@ -70,7 +70,7 @@ fn watched_directory_dir_created() {
         },
         |path, ()| {
             vec![ExpectEvent {
-                full_path: path.clone(),
+                full_path: kqueue_path_file_created_workaround(path),
                 file_path: DIR_NAME,
                 is_dir: true,
                 file_created: true,
@@ -302,7 +302,6 @@ fn watched_directory_dir_metadata_changed() {
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
 fn watched_directory_file_moved_from() {
     test_fs_watcher(
         |watcher, dir| {
@@ -334,7 +333,6 @@ fn watched_directory_file_moved_from() {
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
 fn watched_directory_dir_moved_from() {
     test_fs_watcher(
         |watcher, dir| {
@@ -367,7 +365,6 @@ fn watched_directory_dir_moved_from() {
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
 fn watched_directory_file_moved_to() {
     test_fs_watcher(
         |watcher, dir| {
@@ -383,10 +380,24 @@ fn watched_directory_file_moved_to() {
         },
         |path, ()| {
             vec![ExpectEvent {
-                full_path: path.clone(),
+                full_path: kqueue_path_file_created_workaround(path),
                 file_path: FILE_NAME,
                 file_moved_into: true,
                 file_moved: true,
+                // Event::file_moved_into is not supported by kqueue, but it
+                // will trigger file_created.
+                #[cfg(any(
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "ios",
+                    target_os = "macos",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                    target_os = "tvos",
+                    target_os = "visionos",
+                    target_os = "watchos",
+                ))]
+                file_created: true,
                 ..Default::default()
             }]
         },
@@ -394,7 +405,6 @@ fn watched_directory_file_moved_to() {
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
 fn watched_directory_dir_moved_to() {
     test_fs_watcher(
         |watcher, dir| {
@@ -413,11 +423,25 @@ fn watched_directory_dir_moved_to() {
         },
         |path, ()| {
             vec![ExpectEvent {
-                full_path: path.clone(),
+                full_path: kqueue_path_file_created_workaround(path),
                 file_path: DIR_NAME,
                 is_dir: true,
                 file_moved_into: true,
                 file_moved: true,
+                // Event::file_moved_into is not supported by kqueue, but it
+                // will trigger file_created.
+                #[cfg(any(
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "ios",
+                    target_os = "macos",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                    target_os = "tvos",
+                    target_os = "visionos",
+                    target_os = "watchos",
+                ))]
+                file_created: true,
                 ..Default::default()
             }]
         },
@@ -610,6 +634,7 @@ fn watched_directory_deleted() {
         |path, ()| {
             vec![ExpectEvent {
                 full_path: path.clone(),
+                is_dir: true,
                 deleted: true,
                 ..Default::default()
             }]
@@ -1104,7 +1129,6 @@ impl PartialEq<ExpectEvent> for Event {
         // the field that differs.
         #[cfg(any(target_os = "android", target_os = "linux"))] // Panics for kqueue.
         assert_eq!(self.file_path(), std::path::Path::new(event.file_path), "file_path");
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         assert_eq!(self.is_dir(), event.is_dir, "is_dir");
         #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "netbsd"))]
         assert_eq!(self.accessed(), event.accessed, "accessed");
@@ -1121,14 +1145,35 @@ impl PartialEq<ExpectEvent> for Event {
         assert_eq!(self.deleted(), event.deleted, "deleted");
         assert_eq!(self.moved(), event.moved, "moved");
         assert_eq!(self.unmounted(), event.unmounted, "unmounted");
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         assert_eq!(self.file_moved_from(), event.file_moved_from, "file_moved_from");
+        // Not supported with kqueue.
         #[cfg(any(target_os = "android", target_os = "linux"))]
         assert_eq!(self.file_moved_into(), event.file_moved_into, "file_moved_into");
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        // Event::file_moved_into is not supported by kqueue, so if file_moved_from is false file_moved will also be false.
+        #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd", target_os = "tvos", target_os = "visionos", target_os = "watchos"))]
+        if self.file_moved_from() {
+            assert_eq!(self.file_moved(), event.file_moved, "file_moved");
+        }
+        #[cfg(not(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd", target_os = "tvos", target_os = "visionos", target_os = "watchos")))]
         assert_eq!(self.file_moved(), event.file_moved, "file_moved");
         assert_eq!(self.file_created(), event.file_created, "file_created");
         assert_eq!(self.file_deleted(), event.file_deleted, "file_deleted");
         true
     }
+}
+
+fn kqueue_path_file_created_workaround(mut path: PathBuf) -> PathBuf {
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos",
+    ))]
+    path.pop();
+    path
 }

--- a/tests/functional/fs_notify.rs
+++ b/tests/functional/fs_notify.rs
@@ -519,6 +519,7 @@ fn watched_directory_moved() {
         |path, ()| {
             vec![ExpectEvent {
                 full_path: path.clone(),
+                is_dir: true,
                 moved: true,
                 ..Default::default()
             }]

--- a/tests/functional/fs_notify.rs
+++ b/tests/functional/fs_notify.rs
@@ -47,7 +47,7 @@ fn watched_directory_file_created() {
         },
         |path, ()| {
             vec![ExpectEvent {
-                full_path: kqueue_path_file_created_workaround(path),
+                full_path: path,
                 file_path: FILE_NAME,
                 file_created: true,
                 ..Default::default()
@@ -70,7 +70,7 @@ fn watched_directory_dir_created() {
         },
         |path, ()| {
             vec![ExpectEvent {
-                full_path: kqueue_path_file_created_workaround(path),
+                full_path: path,
                 file_path: DIR_NAME,
                 is_dir: true,
                 file_created: true,
@@ -380,7 +380,7 @@ fn watched_directory_file_moved_to() {
         },
         |path, ()| {
             vec![ExpectEvent {
-                full_path: kqueue_path_file_created_workaround(path),
+                full_path: path,
                 file_path: FILE_NAME,
                 file_moved_into: true,
                 file_moved: true,
@@ -423,7 +423,7 @@ fn watched_directory_dir_moved_to() {
         },
         |path, ()| {
             vec![ExpectEvent {
-                full_path: kqueue_path_file_created_workaround(path),
+                full_path: path,
                 file_path: DIR_NAME,
                 is_dir: true,
                 file_moved_into: true,
@@ -1160,20 +1160,4 @@ impl PartialEq<ExpectEvent> for Event {
         assert_eq!(self.file_deleted(), event.file_deleted, "file_deleted");
         true
     }
-}
-
-fn kqueue_path_file_created_workaround(mut path: PathBuf) -> PathBuf {
-    #[cfg(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "tvos",
-        target_os = "visionos",
-        target_os = "watchos",
-    ))]
-    path.pop();
-    path
 }

--- a/tests/functional/fs_notify.rs
+++ b/tests/functional/fs_notify.rs
@@ -34,6 +34,20 @@ fn event_is_send_and_sync() {
 }
 
 #[test]
+#[cfg_attr(
+    any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos"
+    ),
+    ignore = "is_dir and the path are incorrect for file_created events"
+)]
 fn watched_directory_file_created() {
     test_fs_watcher(
         |watcher, dir| {
@@ -57,6 +71,20 @@ fn watched_directory_file_created() {
 }
 
 #[test]
+#[cfg_attr(
+    any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos"
+    ),
+    ignore = "is_dir and the path are incorrect for file_created events"
+)]
 fn watched_directory_dir_created() {
     test_fs_watcher(
         |watcher, dir| {
@@ -365,6 +393,20 @@ fn watched_directory_dir_moved_from() {
 }
 
 #[test]
+#[cfg_attr(
+    any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos"
+    ),
+    ignore = "is_dir and the path are incorrect for file_created events"
+)]
 fn watched_directory_file_moved_to() {
     test_fs_watcher(
         |watcher, dir| {
@@ -405,6 +447,20 @@ fn watched_directory_file_moved_to() {
 }
 
 #[test]
+#[cfg_attr(
+    any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos"
+    ),
+    ignore = "is_dir and the path are incorrect for file_created events"
+)]
 fn watched_directory_dir_moved_to() {
     test_fs_watcher(
         |watcher, dir| {

--- a/tests/functional/fs_notify.rs
+++ b/tests/functional/fs_notify.rs
@@ -34,7 +34,6 @@ fn event_is_send_and_sync() {
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
 fn watched_directory_file_created() {
     test_fs_watcher(
         |watcher, dir| {
@@ -58,7 +57,6 @@ fn watched_directory_file_created() {
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
 fn watched_directory_dir_created() {
     test_fs_watcher(
         |watcher, dir| {
@@ -1129,7 +1127,6 @@ impl PartialEq<ExpectEvent> for Event {
         assert_eq!(self.file_moved_into(), event.file_moved_into, "file_moved_into");
         #[cfg(any(target_os = "android", target_os = "linux"))]
         assert_eq!(self.file_moved(), event.file_moved, "file_moved");
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         assert_eq!(self.file_created(), event.file_created, "file_created");
         assert_eq!(self.file_deleted(), event.file_deleted, "file_deleted");
         true

--- a/tests/functional/fs_notify.rs
+++ b/tests/functional/fs_notify.rs
@@ -1089,6 +1089,9 @@ async fn expect_events(watcher: &mut fs::Watcher, expected: &[ExpectEvent]) {
             .await
             .expect("missing expected event")
             .expect("failed to read events");
+        println!("Got event: {event:#?}");
+        println!("Path: {}", events.path_for(&event).display());
+        println!("Expected: {expected:#?}");
         assert_eq!(event, expected);
         let full_path = events.path_for(&event);
         assert_eq!(full_path, expected.full_path);

--- a/tests/functional/fs_notify.rs
+++ b/tests/functional/fs_notify.rs
@@ -519,6 +519,7 @@ fn watched_directory_moved() {
         |path, ()| {
             vec![ExpectEvent {
                 full_path: path.clone(),
+                #[cfg(not(any(target_os = "android", target_os = "linux")))] // Not set using inotify.
                 is_dir: true,
                 moved: true,
                 ..Default::default()
@@ -691,6 +692,7 @@ fn watched_directory_deleted() {
         |path, ()| {
             vec![ExpectEvent {
                 full_path: path.clone(),
+                #[cfg(not(any(target_os = "android", target_os = "linux")))] // Not set using inotify.
                 is_dir: true,
                 deleted: true,
                 ..Default::default()

--- a/tests/functional/fs_notify.rs
+++ b/tests/functional/fs_notify.rs
@@ -550,7 +550,6 @@ fn watched_directory_file_closed_write() {
 // NOTE: no close_write event can be generated for directories.
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
 fn watched_directory_dir_deleted() {
     test_fs_watcher(
         |watcher, dir| {
@@ -576,7 +575,6 @@ fn watched_directory_dir_deleted() {
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "linux"))]
 fn watched_directory_file_deleted() {
     test_fs_watcher(
         |watcher, dir| {
@@ -1133,7 +1131,6 @@ impl PartialEq<ExpectEvent> for Event {
         assert_eq!(self.file_moved(), event.file_moved, "file_moved");
         #[cfg(any(target_os = "android", target_os = "linux"))]
         assert_eq!(self.file_created(), event.file_created, "file_created");
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         assert_eq!(self.file_deleted(), event.file_deleted, "file_deleted");
         true
     }


### PR DESCRIPTION
Enable the usage of fs::notify::Interest::MOVE, although MOVE_INTO is not supported. As a work around it triggers Event::file_created as that's the best we can do.

On the fs::notify::Event side is_dir is now supported. Same for file_moved_from and file_moved, file_moved_into will always return false as kqueue doesn't give us enough information to determine this. Event::file_created and file_deleted are fully supported.

Follow up to #268