### PR TITLE
Improve FdIter implementation on kqueue

### DIFF
--- a/src/io/read_buf.rs
+++ b/src/io/read_buf.rs
@@ -123,6 +123,21 @@ impl ReadBufPool {
             owned: None,
         }
     }
+
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos",
+    ))]
+    pub(crate) fn buf_capacity(&self) -> usize {
+        self.shared.buf_size()
+    }
 }
 
 /// Buffer reference from a [`ReadBufPool`].

--- a/src/kqueue/fs_notify.rs
+++ b/src/kqueue/fs_notify.rs
@@ -14,7 +14,7 @@ use std::{fmt, io, mem, ptr};
 use crate::fs::Metadata;
 use crate::fs::notify::{self, Events, Interest, Recursive, Watcher};
 use crate::kqueue::fd::OpKind;
-use crate::kqueue::op::FdIter;
+use crate::kqueue::op::{FdIter, Next};
 use crate::kqueue::{self, kqueue};
 use crate::op::{FdIter as _, OpState};
 use crate::{AsyncFd, SubmissionQueue, syscall};
@@ -458,6 +458,13 @@ impl<'a> FdIter for NotifyOp<'a> {
             }
             Ok(())
         }
+    }
+
+    fn next(_: &Self::Resources, (): &Self::OperationOutput) -> Next {
+        // If we have unprocessed events we need to run again. If we processed
+        // all events we need to check if more events are ready to read. So, we
+        // always want to run again.
+        Next::TryRun
     }
 
     fn map_next(

--- a/src/kqueue/io.rs
+++ b/src/kqueue/io.rs
@@ -239,10 +239,6 @@ impl FdIter for MultishotReadOp {
         }
     }
 
-    fn is_complete((_, n): &Self::OperationOutput) -> bool {
-        *n == 0
-    }
-
     fn next(buf_pool: &Self::Resources, (_, n): &Self::OperationOutput) -> Next {
         match *n {
             // Read of zero means we hit the end of the file (EOF).

--- a/src/kqueue/io.rs
+++ b/src/kqueue/io.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::io::{Buf, BufMut, BufMutParts, BufMutSlice, BufSlice, NO_OFFSET, ReadBuf};
 use crate::kqueue::fd::OpKind;
-use crate::kqueue::op::{DirectOp, FdIter, FdOp, FdOpExtract};
+use crate::kqueue::op::{DirectOp, FdIter, FdOp, FdOpExtract, Next};
 use crate::{AsyncFd, SubmissionQueue, fd, syscall};
 
 // Re-export so we don't have to worry about import `std::io` and `crate::io`.
@@ -217,7 +217,7 @@ impl FdIter for MultishotReadOp {
     type Output = crate::io::ReadBuf;
     type Resources = crate::io::ReadBufPool;
     type Args = ();
-    type OperationOutput = (NonNull<u8>, libc::ssize_t);
+    type OperationOutput = (NonNull<u8>, libc::size_t);
 
     const OP_KIND: OpKind = OpKind::Read;
 
@@ -230,7 +230,7 @@ impl FdIter for MultishotReadOp {
             return Err(io::Error::from_raw_os_error(libc::ENOBUFS));
         };
         match syscall!(read(fd.fd(), ptr.as_ptr().cast(), len as _)) {
-            Ok(n) => Ok((ptr, n)),
+            Ok(n) => Ok((ptr, n.cast_unsigned())),
             Err(err) => {
                 let ptr = NonNull::slice_from_raw_parts(ptr, 0);
                 unsafe { buf_pool.shared.release(ptr) }
@@ -243,6 +243,18 @@ impl FdIter for MultishotReadOp {
         *n == 0
     }
 
+    fn next(buf_pool: &Self::Resources, (_, n): &Self::OperationOutput) -> Next {
+        match *n {
+            // Read of zero means we hit the end of the file (EOF).
+            0 => Next::Complete,
+            // If we've didn't fill the buffer we've drained the readiness and
+            // we don't need to register the fd for reading again.
+            n if n < buf_pool.buf_capacity() => Next::Submit,
+            // Potentially more data available, so need to read again.
+            _ => Next::TryRun,
+        }
+    }
+
     fn map_next(
         _: &AsyncFd,
         buf_pool: &Self::Resources,
@@ -250,7 +262,7 @@ impl FdIter for MultishotReadOp {
     ) -> Self::Output {
         // SAFETY: we got the pointer from the buffer pool in try_run and the
         // kernel initialised n bytes for us.
-        unsafe { buf_pool.new_buffer(ptr, n.cast_unsigned()) }
+        unsafe { buf_pool.new_buffer(ptr, n) }
     }
 }
 

--- a/src/kqueue/mod.rs
+++ b/src/kqueue/mod.rs
@@ -143,38 +143,10 @@ impl Shared {
         for event in events.iter() {
             log::trace!(event:?; "got event");
 
-            if event.0.flags & libc::EV_ERROR != 0 {
-                // Check for the error flag, the actual error will be in the `data`
-                // field.
-                //
+            if event.0.flags & libc::EV_ERROR != 0 && event.0.data == 0 {
                 // If the error number (event.data) is zero it means the event
                 // was succesfully submitted and can be safely ignored.
-                //
-                // Older versions of macOS (OS X 10.11 and 10.10 have been
-                // witnessed) can return EPIPE when registering a pipe file
-                // descriptor where the other end has already disappeared. For
-                // example code that creates a pipe, closes a file descriptor,
-                // and then registers the other end will see an EPIPE returned
-                // from `register`.
-                //
-                // It also turns out that kevent will still report events on the
-                // file descriptor, telling us that it's readable/hup at least
-                // after we've done this registration. As a result we just
-                // ignore `EPIPE` here instead of propagating it.
-                //
-                // More info can be found at https://github.com/tokio-rs/mio#582.
-                //
-                // The ENOENT error informs us that a filter we're trying to remove
-                // wasn't there in first place, but we don't really care since our goal
-                // is accomplished.
-                let errno = event.0.data as i32;
-                if errno == 0 {
-                    continue;
-                } else if !matches!(errno, libc::EPIPE | libc::ENOENT) {
-                    let err = io::Error::from_raw_os_error(errno);
-                    log::warn!(event:?; "submitted change has an error: {err}, dropping it");
-                    continue;
-                }
+                continue;
             }
 
             match event.0.filter {

--- a/src/kqueue/net.rs
+++ b/src/kqueue/net.rs
@@ -5,7 +5,7 @@ use std::{io, slice};
 
 use crate::io::{Buf, BufMut, BufMutSlice, BufSlice, ReadBuf, ReadBufPool};
 use crate::kqueue::fd::OpKind;
-use crate::kqueue::op::{DirectFdOp, DirectOp, FdIter, FdOp, FdOpExtract, impl_fd_op};
+use crate::kqueue::op::{DirectFdOp, DirectOp, FdIter, FdOp, FdOpExtract, Next, impl_fd_op};
 use crate::net::{
     AcceptFlag, AddressStorage, Domain, Level, Name, NoAddress, Opt, OptionStorage, Protocol,
     RecvFlag, SendCall, SendFlag, SocketAddress, Type, option,
@@ -244,7 +244,7 @@ impl FdIter for MultishotRecvOp {
     type Output = ReadBuf;
     type Resources = ReadBufPool;
     type Args = RecvFlag;
-    type OperationOutput = (NonNull<u8>, libc::ssize_t);
+    type OperationOutput = (NonNull<u8>, libc::size_t);
 
     const OP_KIND: OpKind = OpKind::Read;
 
@@ -259,7 +259,7 @@ impl FdIter for MultishotRecvOp {
         };
         let pptr = ptr.as_ptr().cast();
         match syscall!(recv(fd.fd(), pptr, len as _, flags.0.cast_signed())) {
-            Ok(n) => Ok((ptr, n)),
+            Ok(n) => Ok((ptr, n.cast_unsigned())),
             Err(err) => {
                 let ptr = NonNull::slice_from_raw_parts(ptr, 0);
                 unsafe { buf_pool.shared.release(ptr) }
@@ -272,6 +272,18 @@ impl FdIter for MultishotRecvOp {
         *n == 0
     }
 
+    fn next(buf_pool: &Self::Resources, (_, n): &Self::OperationOutput) -> Next {
+        match *n {
+            // Read of zero means we hit the end of the file (EOF).
+            0 => Next::Complete,
+            // If we've didn't fill the buffer we've drained the readiness and
+            // we don't need to register the fd for reading again.
+            n if n < buf_pool.buf_capacity() => Next::Submit,
+            // Potentially more data available, so need to read again.
+            _ => Next::TryRun,
+        }
+    }
+
     fn map_next(
         _: &AsyncFd,
         buf_pool: &Self::Resources,
@@ -279,7 +291,7 @@ impl FdIter for MultishotRecvOp {
     ) -> Self::Output {
         // SAFETY: we got the pointer from the buffer pool in try_run and the
         // kernel initialised n bytes for us.
-        unsafe { buf_pool.new_buffer(ptr, n.cast_unsigned()) }
+        unsafe { buf_pool.new_buffer(ptr, n) }
     }
 }
 
@@ -609,6 +621,14 @@ impl FdIter for MultishotAcceptOp {
     ) -> io::Result<Self::OperationOutput> {
         let mut address = AddressStorage((MaybeUninit::uninit(), 0));
         AcceptOp::<NoAddress>::try_run(fd, &mut address, flags)
+    }
+
+    fn next((): &Self::Resources, _: &Self::OperationOutput) -> Next {
+        // We always need to check if we can accept another connection, so
+        // always run again.
+        // TODO: kqueue gives us the number of connections that can be accepted
+        // in the kevent.data field, can we use that to improve this?
+        Next::TryRun
     }
 
     fn map_next(_: &AsyncFd, (): &Self::Resources, fd: Self::OperationOutput) -> Self::Output {

--- a/src/kqueue/net.rs
+++ b/src/kqueue/net.rs
@@ -268,10 +268,6 @@ impl FdIter for MultishotRecvOp {
         }
     }
 
-    fn is_complete((_, n): &Self::OperationOutput) -> bool {
-        *n == 0
-    }
-
     fn next(buf_pool: &Self::Resources, (_, n): &Self::OperationOutput) -> Next {
         match *n {
             // Read of zero means we hit the end of the file (EOF).

--- a/src/kqueue/op.rs
+++ b/src/kqueue/op.rs
@@ -440,6 +440,9 @@ pub(crate) trait FdIter {
         false
     }
 
+    /// Determine what to do next.
+    fn next(resources: &Self::Resources, output: &Self::OperationOutput) -> Next;
+
     /// Similar to [`FdOp::map_ok`], but this processes one of the results.
     /// Meaning it only have a reference to the resources and doesn't take
     /// ownership of it.
@@ -448,6 +451,16 @@ pub(crate) trait FdIter {
         resources: &Self::Resources,
         output: Self::OperationOutput,
     ) -> Self::Output;
+}
+
+/// Returned by [`FdIter::next`].
+pub(crate) enum Next {
+    /// Call [`FdIter::try_run`] again.
+    TryRun,
+    /// Submit and wait for another event.
+    Submit,
+    /// Operation is complete.
+    Complete,
 }
 
 impl<T: FdIter> crate::op::FdIter for T {

--- a/src/kqueue/op.rs
+++ b/src/kqueue/op.rs
@@ -431,15 +431,6 @@ pub(crate) trait FdIter {
         args: &mut Self::Args,
     ) -> io::Result<Self::OperationOutput>;
 
-    /// Returns true if the operation is finished based on `output`.
-    ///
-    /// Default implementation returns false, meaning it will never stop unless
-    /// an error is hit.
-    fn is_complete(output: &Self::OperationOutput) -> bool {
-        _ = output;
-        false
-    }
-
     /// Determine what to do next.
     fn next(resources: &Self::Resources, output: &Self::OperationOutput) -> Next;
 

--- a/src/kqueue/op.rs
+++ b/src/kqueue/op.rs
@@ -484,22 +484,31 @@ impl<T: FdIter> crate::op::FdIter for T {
             T::try_run,
             |state, output| {
                 debug_assert!(!matches!(state.status, Evented::Complete));
-                if T::is_complete(output) {
-                    state.status = Evented::Complete;
-                    // SAFETY: the old status was not Complete, which means that the
-                    // resources are initialised. Since we've just set the status to
-                    // complete is safe to read the resources and leave the old place
-                    // unitialised.
-                    let resources = unsafe { state.resources.assume_init_read() };
-                    r.insert(resources)
-                } else {
-                    // Need to try the operation again and hit a would block
-                    // error before we can wait for another readiness event.
-                    state.status = Evented::Waiting;
-                    // SAFETY: the old status was not Complete, which means that the
-                    // resources are initialised, so we can safely return a
-                    // reference to it.
-                    unsafe { state.resources.assume_init_ref() }
+                // SAFETY: the old status was not Complete, which means that the
+                // resources are initialised, so we can safely return a
+                // reference to it.
+                let resources = unsafe { state.resources.assume_init_ref() };
+                match T::next(resources, output) {
+                    Next::TryRun => {
+                        // Need to try the operation again and hit a would block
+                        // error before we can wait for another readiness event.
+                        state.status = Evented::Waiting;
+                        resources
+                    }
+                    Next::Submit => {
+                        // Need to submit and wait for another event.
+                        state.status = Evented::ToSubmit;
+                        resources
+                    }
+                    Next::Complete => {
+                        state.status = Evented::Complete;
+                        // SAFETY: the old status was not Complete, which means
+                        // that the resources are initialised. Since we've just
+                        // set the status to complete is safe to read the
+                        // resources and leave the old place unitialised.
+                        let resources = unsafe { state.resources.assume_init_read() };
+                        r.insert(resources)
+                    }
                 }
             },
             T::map_next,

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -18,6 +18,8 @@ mod mem;
 mod net;
 #[path = "functional/net_options.rs"]
 mod net_options;
+#[path = "functional/pipe.rs"]
+mod pipe;
 #[path = "functional/process.rs"]
 mod process;
 #[path = "functional/read_buf.rs"]

--- a/tests/functional/pipe.rs
+++ b/tests/functional/pipe.rs
@@ -1,9 +1,10 @@
+use std::io;
 use std::pin::pin;
 
 use a10::fd;
 use a10::pipe::{Pipe, pipe};
 
-use crate::util::{Waker, is_send, is_sync, poll_nop, test_queue};
+use crate::util::{Waker, expect_io_error_kind, is_send, is_sync, poll_nop, test_queue};
 
 const DATA1: &[u8] = b"Hello from the other side";
 
@@ -51,4 +52,46 @@ fn cancel_pipe() {
     let mut pipe = pin!(pipe(sq));
     _ = poll_nop(pipe.as_mut());
     drop(pipe);
+}
+
+#[test]
+fn writing_to_closed_pipe() {
+    // Older versions of macOS (OS X 10.11 and 10.10 have been witnessed) can
+    // return EPIPE when registering a pipe file descriptor where the other end
+    // has already disappeared. For example code that creates a pipe, closes a
+    // file descriptor, and then registers the other end will see an EPIPE
+    // returned.
+    //
+    // More info can be found at https://github.com/tokio-rs/mio#582.
+    //
+    // We've removed the work around for this (as OS X 10.11 and 10.10 are no
+    // longer supported), but we explicitly want to test the behaviour doesn't
+    // return.
+
+    let sq = test_queue();
+    let waker = Waker::new();
+
+    let [receiver, sender] = waker.block_on(pipe(sq)).expect("failed to create pipe");
+
+    drop(receiver); // Close the fd.
+
+    let res = waker.block_on(sender.write_all(DATA1));
+    expect_io_error_kind(res, io::ErrorKind::BrokenPipe);
+}
+
+#[test]
+fn reading_from_closed_pipe() {
+    // See writing_to_closed_pipe test above for why this is tested.
+
+    let sq = test_queue();
+    let waker = Waker::new();
+
+    let [receiver, sender] = waker.block_on(pipe(sq)).expect("failed to create pipe");
+
+    drop(sender); // Close the fd.
+
+    let buf = waker
+        .block_on(receiver.read(Vec::with_capacity(8)))
+        .expect("failed to read");
+    assert!(buf.is_empty());
 }

--- a/tests/functional/pipe.rs
+++ b/tests/functional/pipe.rs
@@ -1,7 +1,9 @@
+use std::pin::pin;
+
 use a10::fd;
 use a10::pipe::{Pipe, pipe};
 
-use crate::util::{Waker, cancel, is_send, is_sync, start_op, test_queue};
+use crate::util::{Waker, is_send, is_sync, poll_nop, test_queue};
 
 const DATA1: &[u8] = b"Hello from the other side";
 
@@ -17,6 +19,7 @@ fn pipe_file_descriptor() {
 }
 
 #[test]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 fn pipe_direct_descriptor() {
     test_pipe(fd::Kind::Direct)
 }
@@ -44,8 +47,8 @@ fn test_pipe(fd_kind: fd::Kind) {
 #[test]
 fn cancel_pipe() {
     let sq = test_queue();
-    let waker = Waker::new();
 
-    let mut pipe = pipe(sq);
-    cancel(&waker, &mut pipe, start_op);
+    let mut pipe = pin!(pipe(sq));
+    _ = poll_nop(pipe.as_mut());
+    drop(pipe);
 }


### PR DESCRIPTION
The trait now allows the implementation to determine whether or not it's needed to register the resource again, or to simply wait.