### PR TITLE
Remove asan and msan poisoning

### DIFF
--- a/src/asan.rs
+++ b/src/asan.rs
@@ -23,11 +23,13 @@ unsafe extern "C" {
 
 /// Mark a memory region as unaddressable.
 pub(crate) fn poison_region(addr: *const c_void, size: c_size_t) {
+    /*
     #[cfg_attr(feature = "nightly", cfg(sanitize = "address"))]
     #[cfg_attr(not(feature = "nightly"), cfg(false))]
     unsafe {
         __asan_poison_memory_region(addr, size);
     }
+    */
 }
 
 /// Mark memory storing `T` as unaddressable.
@@ -60,11 +62,13 @@ pub(crate) fn poison_cstring(value: &CString) {
 
 /// Mark a memory region as addressable.
 pub(crate) fn unpoison_region(addr: *const c_void, size: c_size_t) {
+    /*
     #[cfg_attr(feature = "nightly", cfg(sanitize = "address"))]
     #[cfg_attr(not(feature = "nightly"), cfg(false))]
     unsafe {
         __asan_unpoison_memory_region(addr, size);
     }
+    */
 }
 
 /// Mark memory storing `T` as addressable.

--- a/src/msan.rs
+++ b/src/msan.rs
@@ -21,11 +21,13 @@ unsafe extern "C" {
 
 /// Mark a memory region as fully initialized.
 pub(crate) fn unpoison_region(addr: *const c_void, size: c_size_t) {
+    /*
     #[cfg_attr(feature = "nightly", cfg(sanitize = "memory"))]
     #[cfg_attr(not(feature = "nightly"), cfg(false))]
     unsafe {
         __msan_unpoison(addr, size);
     }
+    */
 }
 
 /// Mark the first `n` bytes of iovecs as fully initialized.


### PR DESCRIPTION
The santizers are reporting, what seems to be, false positives in the CI. So try removing our custom code and see if the false positives go away.