### PR TITLE
Add synchronous version of various operations

### DIFF
--- a/src/kqueue/net.rs
+++ b/src/kqueue/net.rs
@@ -8,7 +8,8 @@ use crate::kqueue::fd::OpKind;
 use crate::kqueue::op::{DirectFdOp, DirectOp, FdIter, FdOp, FdOpExtract, Next, impl_fd_op};
 use crate::net::{
     AcceptFlag, AddressStorage, Domain, Level, Name, NoAddress, Opt, OptionStorage, Protocol,
-    RecvFlag, SendCall, SendFlag, SocketAddress, Type, option, sync_socket,
+    RecvFlag, SendCall, SendFlag, SocketAddress, Type, option, sync_set_socket_option2,
+    sync_socket, sync_socket_option,
 };
 use crate::{AsyncFd, SubmissionQueue, fd, syscall};
 
@@ -596,22 +597,8 @@ impl<T: option::Get> DirectFdOp for SocketOptionOp<T> {
     type Resources = OptionStorage<MaybeUninit<T::Storage>>;
     type Args = (Level, Opt);
 
-    fn run(
-        fd: &AsyncFd,
-        mut value: Self::Resources,
-        (level, optname): Self::Args,
-    ) -> io::Result<Self::Output> {
-        let (optval, mut optlen) = unsafe { T::as_mut_ptr(&mut value.0) };
-        syscall!(getsockopt(
-            fd.fd(),
-            level.0.cast_signed(),
-            optname.0.cast_signed(),
-            optval,
-            &raw mut optlen,
-        ))?;
-        // SAFETY: the kernel initialised the value for us as part of the
-        // getsockopt call.
-        Ok(unsafe { T::init(value.0, optlen) })
+    fn run(fd: &AsyncFd, _: Self::Resources, (_, _): Self::Args) -> io::Result<Self::Output> {
+        sync_socket_option::<T>(fd)
     }
 }
 
@@ -624,19 +611,8 @@ impl<T: option::Set> DirectFdOp for SetSocketOptionOp<T> {
     type Resources = OptionStorage<T::Storage>;
     type Args = (Level, Opt);
 
-    fn run(
-        fd: &AsyncFd,
-        value: Self::Resources,
-        (level, optname): Self::Args,
-    ) -> io::Result<Self::Output> {
-        syscall!(setsockopt(
-            fd.fd(),
-            level.0.cast_signed(),
-            optname.0.cast_signed(),
-            ptr::from_ref(&value.0).cast(),
-            size_of::<T::Storage>() as _,
-        ))?;
-        Ok(())
+    fn run(fd: &AsyncFd, value: Self::Resources, (_, _): Self::Args) -> io::Result<Self::Output> {
+        sync_set_socket_option2::<T>(fd, &value.0)
     }
 }
 

--- a/src/kqueue/net.rs
+++ b/src/kqueue/net.rs
@@ -8,7 +8,7 @@ use crate::kqueue::fd::OpKind;
 use crate::kqueue::op::{DirectFdOp, DirectOp, FdIter, FdOp, FdOpExtract, Next, impl_fd_op};
 use crate::net::{
     AcceptFlag, AddressStorage, Domain, Level, Name, NoAddress, Opt, OptionStorage, Protocol,
-    RecvFlag, SendCall, SendFlag, SocketAddress, Type, option,
+    RecvFlag, SendCall, SendFlag, SocketAddress, Type, option, sync_socket,
 };
 use crate::{AsyncFd, SubmissionQueue, fd, syscall};
 
@@ -23,54 +23,10 @@ impl DirectOp for SocketOp {
 
     fn run(
         sq: &SubmissionQueue,
-        kind: Self::Resources,
+        fd::Kind::File: Self::Resources,
         (domain, r#type, protocol): Self::Args,
     ) -> io::Result<Self::Output> {
-        let fd::Kind::File = kind;
-
-        let r#type = r#type.0.cast_signed();
-        #[cfg(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-        ))]
-        let r#type = r#type | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
-
-        let socket = syscall!(socket(domain.0, r#type, protocol.0.cast_signed()))?;
-        // SAFETY: just created the socket above.
-        let fd = unsafe { AsyncFd::from_raw_fd(socket, sq.clone()) };
-
-        // Mimic std lib and set SO_NOSIGPIPE on apple systems.
-        #[cfg(any(
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "tvos",
-            target_os = "visionos",
-            target_os = "watchos",
-        ))]
-        syscall!(setsockopt(
-            socket,
-            libc::SOL_SOCKET,
-            libc::SO_NOSIGPIPE,
-            ptr::from_ref(&1).cast(),
-            size_of::<libc::c_int>() as libc::socklen_t
-        ))?;
-
-        // Apple systems don't have SOCK_NONBLOCK or SOCK_CLOEXEC.
-        #[cfg(any(
-            target_os = "ios",
-            target_os = "macos",
-            target_os = "tvos",
-            target_os = "visionos",
-            target_os = "watchos",
-        ))]
-        {
-            syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK))?;
-            syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC))?;
-        }
-
-        Ok(fd)
+        sync_socket(sq.clone(), domain, r#type, Some(protocol))
     }
 }
 

--- a/src/kqueue/pipe.rs
+++ b/src/kqueue/pipe.rs
@@ -1,9 +1,9 @@
+use std::io;
 use std::os::fd::RawFd;
-use std::{io, ptr};
 
 use crate::kqueue::op::DirectOp;
-use crate::pipe::PipeFlag;
-use crate::{AsyncFd, SubmissionQueue, fd, syscall};
+use crate::pipe::{PipeFlag, sync_pipe2};
+use crate::{AsyncFd, SubmissionQueue, fd};
 
 pub(crate) struct PipeOp;
 
@@ -14,50 +14,9 @@ impl DirectOp for PipeOp {
 
     fn run(
         sq: &SubmissionQueue,
-        (mut fds, kind): Self::Resources,
-        _flags: Self::Args,
+        (_, fd::Kind::File): Self::Resources,
+        flags: Self::Args,
     ) -> io::Result<Self::Output> {
-        let fd::Kind::File = kind;
-
-        #[cfg(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-        ))]
-        syscall!(pipe2(
-            ptr::from_mut(&mut fds).cast(),
-            libc::O_NONBLOCK | libc::O_CLOEXEC
-        ))?;
-        #[cfg(not(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-        )))]
-        syscall!(pipe(ptr::from_mut(&mut fds).cast()))?;
-
-        // SAFETY: create the pipe above.
-        let fds = unsafe {
-            [
-                AsyncFd::from_raw(fds[0], kind, sq.clone()),
-                AsyncFd::from_raw(fds[1], kind, sq.clone()),
-            ]
-        };
-
-        #[cfg(not(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-        )))]
-        {
-            syscall!(fcntl(fds[0].fd(), libc::F_SETFL, libc::O_NONBLOCK))?;
-            syscall!(fcntl(fds[0].fd(), libc::F_SETFD, libc::FD_CLOEXEC))?;
-            syscall!(fcntl(fds[1].fd(), libc::F_SETFL, libc::O_NONBLOCK))?;
-            syscall!(fcntl(fds[1].fd(), libc::F_SETFD, libc::FD_CLOEXEC))?;
-        }
-
-        Ok(fds)
+        sync_pipe2(sq.clone(), flags)
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -2,6 +2,9 @@
 //!
 //! To create a new socket ([`AsyncFd`]) use the [`socket`] function, which
 //! issues a non-blocking `socket(2)` call.
+//!
+//! If you're looking for a synchronous version of the `socket` function (for
+//! easier creation in non-async setup code) see [`sync_socket`].
 
 use std::ffi::{OsStr, c_void};
 use std::future::Future;
@@ -22,7 +25,7 @@ use crate::io::{
 };
 use crate::op::{OpState, fd_iter_operation, fd_operation, operation};
 use crate::sys::net::MsgHeader;
-use crate::{AsyncFd, SubmissionQueue, fd, man_link, new_flag, sys};
+use crate::{AsyncFd, SubmissionQueue, fd, man_link, new_flag, sys, syscall};
 
 pub mod option;
 
@@ -36,6 +39,67 @@ pub fn socket(
 ) -> Socket {
     let args = (domain, r#type, protocol.unwrap_or(Protocol(0)));
     Socket::new(sq, fd::Kind::File, args)
+}
+
+/// Synchronous version of [`socket`].
+///
+/// # Notes
+///
+/// This does not support direct descriptors, only regular file descriptors.
+pub fn sync_socket(
+    sq: SubmissionQueue,
+    domain: Domain,
+    r#type: Type,
+    protocol: Option<Protocol>,
+) -> io::Result<AsyncFd> {
+    let r#type = r#type.0.cast_signed();
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    ))]
+    let r#type = r#type | libc::SOCK_CLOEXEC;
+    // NOTE: io_uring doesn't need SOCK_NONBLOCK.
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    ))]
+    let r#type = r#type | libc::SOCK_NONBLOCK;
+
+    let protocol = protocol.unwrap_or(Protocol(0));
+    let socket = syscall!(socket(domain.0, r#type, protocol.0.cast_signed()))?;
+    // SAFETY: just created the socket above.
+    let fd = unsafe { AsyncFd::from_raw_fd(socket, sq) };
+
+    // For OS that don't support SOCK_{NONBLOCK,CLOEXEC}, we set them after
+    // opening.
+    #[cfg(any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos",
+    ))]
+    {
+        syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK))?;
+        syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC))?;
+
+        // Mimic std lib and set SO_NOSIGPIPE on Apple systems.
+        syscall!(setsockopt(
+            socket,
+            libc::SOL_SOCKET,
+            libc::SO_NOSIGPIPE,
+            ptr::from_ref(&1).cast(),
+            size_of::<libc::c_int>() as libc::socklen_t
+        ))?;
+    }
+
+    Ok(fd)
 }
 
 new_flag!(

--- a/src/net.rs
+++ b/src/net.rs
@@ -43,7 +43,7 @@ pub fn socket(
 
 /// Synchronous version of [`socket`].
 ///
-/// Also see [`sync_bind`].
+/// Also see [`sync_bind`] and [`sync_listen`].
 ///
 /// # Notes
 ///
@@ -470,6 +470,20 @@ pub fn sync_bind<A: SocketAddress>(fd: &AsyncFd, address: A) -> io::Result<()> {
     let address_storage = address.into_storage();
     let (ptr, length) = unsafe { A::as_ptr(&address_storage) };
     syscall!(bind(fd.fd(), ptr.cast(), length))?;
+    Ok(())
+}
+
+/// Synchronous version of [`AsyncFd::listen`].
+///
+/// # Notes
+///
+/// This does not support direct descriptors, only regular file descriptors.
+pub fn sync_listen(fd: &AsyncFd, backlog: u32) -> io::Result<()> {
+    if !matches!(fd.kind(), fd::Kind::File) {
+        return Err(io::ErrorKind::Unsupported.into());
+    }
+
+    syscall!(listen(fd.fd(), backlog.cast_signed()))?;
     Ok(())
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -1014,6 +1014,59 @@ macro_rules! impl_from {
 
 impl_from!(Opt <- SocketOpt, IPv4Opt, IPv6Opt, TcpOpt, UdpOpt, UnixOpt);
 
+/// Synchronous version of [`AsyncFd::socket_option`].
+///
+/// # Notes
+///
+/// This does not support direct descriptors, only regular file descriptors.
+pub fn sync_socket_option<T: option::Get>(fd: &AsyncFd) -> io::Result<<T as option::Get>::Output> {
+    if !matches!(fd.kind(), fd::Kind::File) {
+        return Err(io::ErrorKind::Unsupported.into());
+    }
+
+    let mut value = OptionStorage(MaybeUninit::uninit());
+    let (optval, mut optlen) = unsafe { T::as_mut_ptr(&mut value.0) };
+    syscall!(getsockopt(
+        fd.fd(),
+        T::LEVEL.0.cast_signed(),
+        T::OPT.0.cast_signed(),
+        optval,
+        &raw mut optlen,
+    ))?;
+    // SAFETY: the kernel initialised the value for us as part of the getsockopt
+    // call.
+    Ok(unsafe { T::init(value.0, optlen) })
+}
+
+/// Synchronous version of [`AsyncFd::set_socket_option`].
+///
+/// # Notes
+///
+/// This does not support direct descriptors, only regular file descriptors.
+pub fn sync_set_socket_option<T: option::Set>(fd: &AsyncFd, value: T::Value) -> io::Result<()> {
+    let storage = T::as_storage(value);
+    sync_set_socket_option2::<T>(fd, &storage)
+}
+
+// NOTE: used by kqueue impl (with T::Storage, instead of T::Value).
+pub(crate) fn sync_set_socket_option2<T: option::Set>(
+    fd: &AsyncFd,
+    storage: &T::Storage,
+) -> io::Result<()> {
+    if !matches!(fd.kind(), fd::Kind::File) {
+        return Err(io::ErrorKind::Unsupported.into());
+    }
+
+    syscall!(setsockopt(
+        fd.fd(),
+        T::LEVEL.0.cast_signed(),
+        T::OPT.0.cast_signed(),
+        ptr::from_ref(storage).cast(),
+        size_of::<T::Storage>() as _,
+    ))?;
+    Ok(())
+}
+
 fd_operation! {
     /// [`Future`] behind [`AsyncFd::bind`].
     pub struct Bind<A: SocketAddress>(sys::net::BindOp<A>) -> io::Result<()>;

--- a/src/net.rs
+++ b/src/net.rs
@@ -43,6 +43,8 @@ pub fn socket(
 
 /// Synchronous version of [`socket`].
 ///
+/// Also see [`sync_bind`].
+///
 /// # Notes
 ///
 /// This does not support direct descriptors, only regular file descriptors.
@@ -453,6 +455,22 @@ impl AsyncFd {
     pub fn shutdown<'fd>(&'fd self, how: std::net::Shutdown) -> Shutdown<'fd> {
         Shutdown::new(self, (), how)
     }
+}
+
+/// Synchronous version of [`AsyncFd::bind`].
+///
+/// # Notes
+///
+/// This does not support direct descriptors, only regular file descriptors.
+pub fn sync_bind<A: SocketAddress>(fd: &AsyncFd, address: A) -> io::Result<()> {
+    if !matches!(fd.kind(), fd::Kind::File) {
+        return Err(io::ErrorKind::Unsupported.into());
+    }
+
+    let address_storage = address.into_storage();
+    let (ptr, length) = unsafe { A::as_ptr(&address_storage) };
+    syscall!(bind(fd.fd(), ptr.cast(), length))?;
+    Ok(())
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -2,12 +2,16 @@
 //!
 //! To create a new pipe use the [`pipe`] function. It will return two
 //! [`AsyncFd`]s, the sending and receiving side.
+//!
+//! If you're looking for a synchronous version of the `pipe` function (for
+//! easier creation in non-async setup code) see [`sync_pipe`] and
+//! [`sync_pipe2`].
 
-use std::io;
+use std::{io, ptr};
 
 use crate::fd::{self, AsyncFd};
 use crate::op::{OpState, operation};
-use crate::{SubmissionQueue, man_link, new_flag, sys};
+use crate::{SubmissionQueue, man_link, new_flag, sys, syscall};
 
 /// Create a new Unix pipe.
 ///
@@ -82,4 +86,74 @@ impl Pipe {
         }
         self
     }
+}
+
+/// Synchronous version of [`pipe`].
+///
+/// See [`sync_pipe2`] for more.
+pub fn sync_pipe(sq: SubmissionQueue) -> io::Result<[AsyncFd; 2]> {
+    sync_pipe2(sq, PipeFlag(0))
+}
+
+/// Synchronous version of [`pipe`].
+///
+/// # Notes
+///
+/// This does not support direct descriptors, only regular file descriptors.
+pub fn sync_pipe2(sq: SubmissionQueue, flags: PipeFlag) -> io::Result<[AsyncFd; 2]> {
+    let mut fds = [-1, -1];
+
+    let flags = flags.0 as libc::c_int | libc::O_CLOEXEC;
+    // NOTE: io_uring doesn't need NON_BLOCK.
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    ))]
+    let flags = flags | libc::O_NONBLOCK;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    ))]
+    syscall!(pipe2(ptr::from_mut(&mut fds).cast(), flags))?;
+    #[cfg(any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos",
+    ))]
+    syscall!(pipe(ptr::from_mut(&mut fds).cast()))?;
+
+    // SAFETY: created the pipe fds above.
+    let fds = unsafe {
+        [
+            AsyncFd::from_raw(fds[0], fd::Kind::File, sq.clone()),
+            AsyncFd::from_raw(fds[1], fd::Kind::File, sq),
+        ]
+    };
+
+    // OS that don't support pipe2, we set NONBLOCK and CLOEXEC after opening.
+    #[cfg(any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos",
+    ))]
+    {
+        syscall!(fcntl(fds[0].fd(), libc::F_SETFL, libc::O_NONBLOCK))?;
+        syscall!(fcntl(fds[0].fd(), libc::F_SETFD, libc::FD_CLOEXEC))?;
+        syscall!(fcntl(fds[1].fd(), libc::F_SETFL, libc::O_NONBLOCK))?;
+        syscall!(fcntl(fds[1].fd(), libc::F_SETFD, libc::FD_CLOEXEC))?;
+        let _ = flags;
+    }
+
+    Ok(fds)
 }

--- a/tests/functional/net.rs
+++ b/tests/functional/net.rs
@@ -5,12 +5,13 @@ use std::sync::{Arc, Barrier, OnceLock};
 use std::thread;
 
 use a10::io::ReadBufPool;
-use a10::net::{
-    Accept, Bind, Connect, MultishotAccept, MultishotRecv, NoAddress, Recv, RecvN, RecvNVectored,
-    Send, SendAll, SendAllVectored, SendTo, Socket, SocketName,
-};
 #[cfg(any(target_os = "android", target_os = "linux"))]
-use a10::net::{Domain, Type, socket};
+use a10::net::socket;
+use a10::net::{
+    Accept, Bind, Connect, Domain, MultishotAccept, MultishotRecv, NoAddress, Protocol, Recv,
+    RecvN, RecvNVectored, Send, SendAll, SendAllVectored, SendTo, Socket, SocketName, Type,
+    sync_socket,
+};
 use a10::{Extract, SubmissionQueue};
 
 use crate::util::{
@@ -32,6 +33,49 @@ fn socket_is_send_and_sync() {
 fn bind_is_send_and_sync() {
     is_send::<Bind<SocketAddr>>();
     is_sync::<Bind<SocketAddr>>();
+}
+
+#[test]
+fn sync_socket_listener() {
+    let sq = test_queue();
+    let waker = Waker::new();
+
+    let address: SocketAddr = ([127, 0, 0, 1], 0).into();
+    let domain = Domain::for_address(&address);
+    let listener = sync_socket(sq, domain, Type::STREAM, Some(Protocol::TCP)).unwrap();
+
+    waker.block_on(listener.bind(address)).unwrap();
+    waker.block_on(listener.listen(1)).unwrap();
+    let local_addr = waker.block_on(listener.local_addr()).unwrap();
+
+    // Accept a connection.
+    let mut stream = TcpStream::connect(local_addr).unwrap();
+    let accept = listener.accept::<SocketAddr>();
+    let (client, address) = waker.block_on(accept).unwrap();
+    assert_eq!(stream.peer_addr().unwrap(), local_addr);
+    assert_eq!(stream.local_addr().unwrap(), address.into());
+
+    // Read some data.
+    stream.write(DATA1).expect("failed to write");
+    let mut buf = waker
+        .block_on(client.read(Vec::with_capacity(DATA1.len() + 1)))
+        .expect("failed to read");
+    assert_eq!(buf, DATA1);
+
+    // Write some data.
+    let n = waker
+        .block_on(client.write(DATA2))
+        .expect("failed to write");
+    assert_eq!(n, DATA2.len());
+    buf.resize(DATA2.len() + 1, 0);
+    let n = stream.read(&mut buf).expect("failed to read");
+    assert_eq!(&buf[..n], DATA2);
+
+    // Closing the client should get a result.
+    drop(stream);
+    buf.clear();
+    let buf = waker.block_on(client.read(buf)).expect("failed to read");
+    assert!(buf.is_empty());
 }
 
 #[test]

--- a/tests/functional/net.rs
+++ b/tests/functional/net.rs
@@ -10,7 +10,7 @@ use a10::net::socket;
 use a10::net::{
     Accept, Bind, Connect, Domain, MultishotAccept, MultishotRecv, NoAddress, Protocol, Recv,
     RecvN, RecvNVectored, Send, SendAll, SendAllVectored, SendTo, Socket, SocketName, Type,
-    sync_socket,
+    sync_bind, sync_socket,
 };
 use a10::{Extract, SubmissionQueue};
 
@@ -44,7 +44,7 @@ fn sync_socket_listener() {
     let domain = Domain::for_address(&address);
     let listener = sync_socket(sq, domain, Type::STREAM, Some(Protocol::TCP)).unwrap();
 
-    waker.block_on(listener.bind(address)).unwrap();
+    sync_bind(&listener, address).unwrap();
     waker.block_on(listener.listen(1)).unwrap();
     let local_addr = waker.block_on(listener.local_addr()).unwrap();
 

--- a/tests/functional/net.rs
+++ b/tests/functional/net.rs
@@ -9,8 +9,8 @@ use a10::io::ReadBufPool;
 use a10::net::socket;
 use a10::net::{
     Accept, Bind, Connect, Domain, MultishotAccept, MultishotRecv, NoAddress, Protocol, Recv,
-    RecvN, RecvNVectored, Send, SendAll, SendAllVectored, SendTo, Socket, SocketName, Type,
-    sync_bind, sync_listen, sync_socket,
+    RecvN, RecvNVectored, Send, SendAll, SendAllVectored, SendTo, Socket, SocketName, Type, option,
+    sync_bind, sync_listen, sync_set_socket_option, sync_socket, sync_socket_option,
 };
 use a10::{Extract, SubmissionQueue};
 
@@ -43,6 +43,12 @@ fn sync_socket_listener() {
     let address: SocketAddr = ([127, 0, 0, 1], 0).into();
     let domain = Domain::for_address(&address);
     let listener = sync_socket(sq, domain, Type::STREAM, Some(Protocol::TCP)).unwrap();
+
+    sync_set_socket_option::<option::ReuseAddress>(&listener, true).unwrap();
+    assert_eq!(
+        sync_socket_option::<option::ReuseAddress>(&listener).unwrap(),
+        true,
+    );
 
     sync_bind(&listener, address).unwrap();
     sync_listen(&listener, 1).unwrap();

--- a/tests/functional/net.rs
+++ b/tests/functional/net.rs
@@ -10,7 +10,7 @@ use a10::net::socket;
 use a10::net::{
     Accept, Bind, Connect, Domain, MultishotAccept, MultishotRecv, NoAddress, Protocol, Recv,
     RecvN, RecvNVectored, Send, SendAll, SendAllVectored, SendTo, Socket, SocketName, Type,
-    sync_bind, sync_socket,
+    sync_bind, sync_listen, sync_socket,
 };
 use a10::{Extract, SubmissionQueue};
 
@@ -45,7 +45,7 @@ fn sync_socket_listener() {
     let listener = sync_socket(sq, domain, Type::STREAM, Some(Protocol::TCP)).unwrap();
 
     sync_bind(&listener, address).unwrap();
-    waker.block_on(listener.listen(1)).unwrap();
+    sync_listen(&listener, 1).unwrap();
     let local_addr = waker.block_on(listener.local_addr()).unwrap();
 
     // Accept a connection.

--- a/tests/functional/pipe.rs
+++ b/tests/functional/pipe.rs
@@ -1,8 +1,8 @@
 use std::io;
 use std::pin::pin;
 
-use a10::fd;
-use a10::pipe::{Pipe, pipe};
+use a10::fd::{self, AsyncFd};
+use a10::pipe::{Pipe, pipe, sync_pipe};
 
 use crate::util::{Waker, expect_io_error_kind, is_send, is_sync, poll_nop, test_queue};
 
@@ -16,22 +16,30 @@ fn pipe_is_send_and_sync() {
 
 #[test]
 fn pipe_file_descriptor() {
-    test_pipe(fd::Kind::File)
+    test_pipe(create_async(fd::Kind::File))
 }
 
 #[test]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn pipe_direct_descriptor() {
-    test_pipe(fd::Kind::Direct)
+    test_pipe(create_async(fd::Kind::Direct))
 }
 
-fn test_pipe(fd_kind: fd::Kind) {
+#[test]
+fn sync_pipe_file_descriptor() {
     let sq = test_queue();
-    let waker = Waker::new();
+    test_pipe(sync_pipe(sq).expect("failed to create pipe"))
+}
 
-    let [receiver, sender] = waker
+fn create_async(fd_kind: fd::Kind) -> [AsyncFd; 2] {
+    let sq = test_queue();
+    Waker::new()
         .block_on(pipe(sq).kind(fd_kind))
-        .expect("failed to create pipe");
+        .expect("failed to create pipe")
+}
+
+fn test_pipe([receiver, sender]: [AsyncFd; 2]) {
+    let waker = Waker::new();
 
     // Send some data.
     waker


### PR DESCRIPTION
In certain cases, such as in setup code, you want to use synchronous system calls over asynchronous ones simply because it's easier to deal with, or the async runtime maybe hasn't even start yet. These function are for those cases.