### PR TITLE
Remove unneeded args from (Set)SocketOptionOps

### DIFF
--- a/src/io_uring/net.rs
+++ b/src/io_uring/net.rs
@@ -8,8 +8,8 @@ use crate::io_uring::io::PoolBufParts;
 use crate::io_uring::op::{FdIter, FdOp, FdOpExtract, Op, OpReturn};
 use crate::io_uring::{libc, sq};
 use crate::net::{
-    AcceptFlag, AddressStorage, Domain, Level, Name, NoAddress, Opt, OptionStorage, Protocol,
-    RecvFlag, SendCall, SendFlag, SocketAddress, Type, option,
+    AcceptFlag, AddressStorage, Domain, Name, NoAddress, OptionStorage, Protocol, RecvFlag,
+    SendCall, SendFlag, SocketAddress, Type, option,
 };
 use crate::{AsyncFd, SubmissionQueue, asan, fd, msan, syscall};
 
@@ -675,13 +675,13 @@ pub(crate) struct SocketOptionOp<T>(PhantomData<*const T>);
 impl<T: option::Get> FdOp for SocketOptionOp<T> {
     type Output = T::Output;
     type Resources = OptionStorage<MaybeUninit<T::Storage>>;
-    type Args = (Level, Opt);
+    type Args = ();
 
     #[allow(clippy::cast_sign_loss)] // For level and optname as u32.
     fn fill_submission(
         fd: &AsyncFd,
         value: &mut Self::Resources,
-        (level, optname): &mut Self::Args,
+        (): &mut Self::Args,
         submission: &mut sq::Submission,
     ) {
         submission.0.opcode = libc::IORING_OP_URING_CMD as u8;
@@ -694,8 +694,8 @@ impl<T: option::Get> FdOp for SocketOptionOp<T> {
         };
         submission.0.__bindgen_anon_2 = libc::io_uring_sqe__bindgen_ty_2 {
             __bindgen_anon_1: libc::io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
-                level: level.0,
-                optname: optname.0,
+                level: T::LEVEL.0,
+                optname: T::OPT.0,
             },
         };
         // SAFETY: the kernel will initiase the value for us.
@@ -723,13 +723,13 @@ pub(crate) struct SetSocketOptionOp<T>(PhantomData<*const T>);
 impl<T: option::Set> FdOp for SetSocketOptionOp<T> {
     type Output = ();
     type Resources = OptionStorage<T::Storage>;
-    type Args = (Level, Opt);
+    type Args = ();
 
     #[allow(clippy::cast_sign_loss)] // For level and optname as u32.
     fn fill_submission(
         fd: &AsyncFd,
         value: &mut Self::Resources,
-        (level, optname): &mut Self::Args,
+        (): &mut Self::Args,
         submission: &mut sq::Submission,
     ) {
         submission.0.opcode = libc::IORING_OP_URING_CMD as u8;
@@ -742,8 +742,8 @@ impl<T: option::Set> FdOp for SetSocketOptionOp<T> {
         };
         submission.0.__bindgen_anon_2 = libc::io_uring_sqe__bindgen_ty_2 {
             __bindgen_anon_1: libc::io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
-                level: level.0,
-                optname: optname.0,
+                level: T::LEVEL.0,
+                optname: T::OPT.0,
             },
         };
         submission.0.__bindgen_anon_5 = libc::io_uring_sqe__bindgen_ty_5 {

--- a/src/kqueue/net.rs
+++ b/src/kqueue/net.rs
@@ -7,8 +7,8 @@ use crate::io::{Buf, BufMut, BufMutSlice, BufSlice, ReadBuf, ReadBufPool};
 use crate::kqueue::fd::OpKind;
 use crate::kqueue::op::{DirectFdOp, DirectOp, FdIter, FdOp, FdOpExtract, Next, impl_fd_op};
 use crate::net::{
-    AcceptFlag, AddressStorage, Domain, Level, Name, NoAddress, Opt, OptionStorage, Protocol,
-    RecvFlag, SendCall, SendFlag, SocketAddress, Type, option,
+    AcceptFlag, AddressStorage, Domain, Name, NoAddress, OptionStorage, Protocol, RecvFlag,
+    SendCall, SendFlag, SocketAddress, Type, option,
 };
 use crate::{AsyncFd, SubmissionQueue, fd, syscall};
 
@@ -638,18 +638,14 @@ pub(crate) struct SocketOptionOp<T>(PhantomData<*const T>);
 impl<T: option::Get> DirectFdOp for SocketOptionOp<T> {
     type Output = T::Output;
     type Resources = OptionStorage<MaybeUninit<T::Storage>>;
-    type Args = (Level, Opt);
+    type Args = ();
 
-    fn run(
-        fd: &AsyncFd,
-        mut value: Self::Resources,
-        (level, optname): Self::Args,
-    ) -> io::Result<Self::Output> {
+    fn run(fd: &AsyncFd, mut value: Self::Resources, (): Self::Args) -> io::Result<Self::Output> {
         let (optval, mut optlen) = unsafe { T::as_mut_ptr(&mut value.0) };
         syscall!(getsockopt(
             fd.fd(),
-            level.0.cast_signed(),
-            optname.0.cast_signed(),
+            T::LEVEL.0.cast_signed(),
+            T::OPT.0.cast_signed(),
             optval,
             &raw mut optlen,
         ))?;
@@ -666,17 +662,13 @@ pub(crate) struct SetSocketOptionOp<T>(PhantomData<*const T>);
 impl<T: option::Set> DirectFdOp for SetSocketOptionOp<T> {
     type Output = ();
     type Resources = OptionStorage<T::Storage>;
-    type Args = (Level, Opt);
+    type Args = ();
 
-    fn run(
-        fd: &AsyncFd,
-        value: Self::Resources,
-        (level, optname): Self::Args,
-    ) -> io::Result<Self::Output> {
+    fn run(fd: &AsyncFd, value: Self::Resources, (): Self::Args) -> io::Result<Self::Output> {
         syscall!(setsockopt(
             fd.fd(),
-            level.0.cast_signed(),
-            optname.0.cast_signed(),
+            T::LEVEL.0.cast_signed(),
+            T::OPT.0.cast_signed(),
             ptr::from_ref(&value.0).cast(),
             size_of::<T::Storage>() as _,
         ))?;

--- a/src/net.rs
+++ b/src/net.rs
@@ -367,7 +367,7 @@ impl AsyncFd {
     #[doc(alias = "getsockopt")]
     pub fn socket_option<'fd, T: option::Get>(&'fd self) -> SocketOption<'fd, T> {
         let value = OptionStorage(MaybeUninit::uninit());
-        SocketOption::new(self, value, (T::LEVEL, T::OPT))
+        SocketOption::new(self, value, ())
     }
 
     /// Set socket option.
@@ -381,7 +381,7 @@ impl AsyncFd {
         value: T::Value,
     ) -> SetSocketOption<'fd, T> {
         let value = OptionStorage(T::as_storage(value));
-        SetSocketOption::new(self, value, (T::LEVEL, T::OPT))
+        SetSocketOption::new(self, value, ())
     }
 
     /// Shuts down the read, write, or both halves of this connection.


### PR DESCRIPTION
Since the level and optname are both constants defined on T, and we have T in the Op, we can use the constant directly in the code instead of passing them via the args.