### PR TITLE
Use OwnedFd and AsFd in sync functions

### DIFF
--- a/src/kqueue/net.rs
+++ b/src/kqueue/net.rs
@@ -9,7 +9,7 @@ use crate::kqueue::op::{DirectFdOp, DirectOp, FdIter, FdOp, FdOpExtract, Next, i
 use crate::net::{
     AcceptFlag, AddressStorage, Domain, Name, NoAddress, OptionStorage, Protocol, RecvFlag,
     SendCall, SendFlag, SocketAddress, Type, option, sync_set_socket_option2, sync_socket,
-    sync_socket_option,
+    sync_socket_option2,
 };
 use crate::{AsyncFd, SubmissionQueue, fd, syscall};
 
@@ -598,7 +598,7 @@ impl<T: option::Get> DirectFdOp for SocketOptionOp<T> {
     type Args = ();
 
     fn run(fd: &AsyncFd, _: Self::Resources, (): Self::Args) -> io::Result<Self::Output> {
-        sync_socket_option::<T>(fd)
+        sync_socket_option2::<T>(fd.fd())
     }
 }
 
@@ -612,7 +612,7 @@ impl<T: option::Set> DirectFdOp for SetSocketOptionOp<T> {
     type Args = ();
 
     fn run(fd: &AsyncFd, value: Self::Resources, (): Self::Args) -> io::Result<Self::Output> {
-        sync_set_socket_option2::<T>(fd, &value.0)
+        sync_set_socket_option2::<T>(fd.fd(), &value.0)
     }
 }
 

--- a/src/kqueue/net.rs
+++ b/src/kqueue/net.rs
@@ -27,7 +27,7 @@ impl DirectOp for SocketOp {
         fd::Kind::File: Self::Resources,
         (domain, r#type, protocol): Self::Args,
     ) -> io::Result<Self::Output> {
-        sync_socket(sq.clone(), domain, r#type, Some(protocol))
+        sync_socket(domain, r#type, Some(protocol)).map(|fd| AsyncFd::new(fd, sq.clone()))
     }
 }
 

--- a/src/kqueue/pipe.rs
+++ b/src/kqueue/pipe.rs
@@ -17,6 +17,6 @@ impl DirectOp for PipeOp {
         (_, fd::Kind::File): Self::Resources,
         flags: Self::Args,
     ) -> io::Result<Self::Output> {
-        sync_pipe2(sq.clone(), flags)
+        sync_pipe2(flags).map(|[r, s]| [AsyncFd::new(r, sq.clone()), AsyncFd::new(s, sq.clone())])
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -472,6 +472,19 @@ pub fn sync_listen(fd: impl AsFd, backlog: u32) -> io::Result<()> {
     Ok(())
 }
 
+/// Synchronous version of [`AsyncFd::local_addr`].
+pub fn sync_local_addr<A: SocketAddress>(fd: impl AsFd) -> io::Result<A> {
+    let mut addr = MaybeUninit::uninit();
+    let (ptr, mut length) = unsafe { A::as_mut_ptr(&mut addr) };
+    syscall!(getsockname(
+        fd.as_fd().as_raw_fd(),
+        ptr.cast(),
+        &raw mut length
+    ))?;
+    // SAFETY: the kernel has written the address for us.
+    Ok(unsafe { A::init(addr, length) })
+}
+
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum Name {
     Local,

--- a/src/net.rs
+++ b/src/net.rs
@@ -10,6 +10,7 @@ use std::ffi::{OsStr, c_void};
 use std::future::Future;
 use std::mem::{self, MaybeUninit};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::os::fd::{FromRawFd, OwnedFd};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use std::os::linux::net::SocketAddrExt;
 use std::os::unix;
@@ -47,13 +48,13 @@ pub fn socket(
 ///
 /// # Notes
 ///
-/// This does not support direct descriptors, only regular file descriptors.
+/// The returned fd is setup such that it can be converted into an [`AsyncFd`]
+/// without any further changes required to it.
 pub fn sync_socket(
-    sq: SubmissionQueue,
     domain: Domain,
     r#type: Type,
     protocol: Option<Protocol>,
-) -> io::Result<AsyncFd> {
+) -> io::Result<OwnedFd> {
     let r#type = r#type.0.cast_signed();
     #[cfg(any(
         target_os = "android",
@@ -76,7 +77,7 @@ pub fn sync_socket(
     let protocol = protocol.unwrap_or(Protocol(0));
     let socket = syscall!(socket(domain.0, r#type, protocol.0.cast_signed()))?;
     // SAFETY: just created the socket above.
-    let fd = unsafe { AsyncFd::from_raw_fd(socket, sq) };
+    let fd = unsafe { OwnedFd::from_raw_fd(socket) };
 
     // For OS that don't support SOCK_{NONBLOCK,CLOEXEC}, we set them after
     // opening.

--- a/src/net.rs
+++ b/src/net.rs
@@ -10,7 +10,7 @@ use std::ffi::{OsStr, c_void};
 use std::future::Future;
 use std::mem::{self, MaybeUninit};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
-use std::os::fd::{FromRawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use std::os::linux::net::SocketAddrExt;
 use std::os::unix;
@@ -1016,19 +1016,18 @@ macro_rules! impl_from {
 impl_from!(Opt <- SocketOpt, IPv4Opt, IPv6Opt, TcpOpt, UdpOpt, UnixOpt);
 
 /// Synchronous version of [`AsyncFd::socket_option`].
-///
-/// # Notes
-///
-/// This does not support direct descriptors, only regular file descriptors.
-pub fn sync_socket_option<T: option::Get>(fd: &AsyncFd) -> io::Result<<T as option::Get>::Output> {
-    if !matches!(fd.kind(), fd::Kind::File) {
-        return Err(io::ErrorKind::Unsupported.into());
-    }
+pub fn sync_socket_option<T: option::Get>(fd: impl AsFd) -> io::Result<<T as option::Get>::Output> {
+    sync_socket_option2::<T>(fd.as_fd().as_raw_fd())
+}
 
+// NOTE: used by kqueue impl.
+pub(crate) fn sync_socket_option2<T: option::Get>(
+    fd: RawFd,
+) -> io::Result<<T as option::Get>::Output> {
     let mut value = OptionStorage(MaybeUninit::uninit());
     let (optval, mut optlen) = unsafe { T::as_mut_ptr(&mut value.0) };
     syscall!(getsockopt(
-        fd.fd(),
+        fd,
         T::LEVEL.0.cast_signed(),
         T::OPT.0.cast_signed(),
         optval,
@@ -1040,26 +1039,18 @@ pub fn sync_socket_option<T: option::Get>(fd: &AsyncFd) -> io::Result<<T as opti
 }
 
 /// Synchronous version of [`AsyncFd::set_socket_option`].
-///
-/// # Notes
-///
-/// This does not support direct descriptors, only regular file descriptors.
-pub fn sync_set_socket_option<T: option::Set>(fd: &AsyncFd, value: T::Value) -> io::Result<()> {
+pub fn sync_set_socket_option<T: option::Set>(fd: impl AsFd, value: T::Value) -> io::Result<()> {
     let storage = T::as_storage(value);
-    sync_set_socket_option2::<T>(fd, &storage)
+    sync_set_socket_option2::<T>(fd.as_fd().as_raw_fd(), &storage)
 }
 
 // NOTE: used by kqueue impl (with T::Storage, instead of T::Value).
 pub(crate) fn sync_set_socket_option2<T: option::Set>(
-    fd: &AsyncFd,
+    fd: RawFd,
     storage: &T::Storage,
 ) -> io::Result<()> {
-    if !matches!(fd.kind(), fd::Kind::File) {
-        return Err(io::ErrorKind::Unsupported.into());
-    }
-
     syscall!(setsockopt(
-        fd.fd(),
+        fd,
         T::LEVEL.0.cast_signed(),
         T::OPT.0.cast_signed(),
         ptr::from_ref(storage).cast(),

--- a/src/net.rs
+++ b/src/net.rs
@@ -467,16 +467,8 @@ pub fn sync_bind<A: SocketAddress>(fd: impl AsFd, address: A) -> io::Result<()> 
 }
 
 /// Synchronous version of [`AsyncFd::listen`].
-///
-/// # Notes
-///
-/// This does not support direct descriptors, only regular file descriptors.
-pub fn sync_listen(fd: &AsyncFd, backlog: u32) -> io::Result<()> {
-    if !matches!(fd.kind(), fd::Kind::File) {
-        return Err(io::ErrorKind::Unsupported.into());
-    }
-
-    syscall!(listen(fd.fd(), backlog.cast_signed()))?;
+pub fn sync_listen(fd: impl AsFd, backlog: u32) -> io::Result<()> {
+    syscall!(listen(fd.as_fd().as_raw_fd(), backlog.cast_signed()))?;
     Ok(())
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -459,18 +459,10 @@ impl AsyncFd {
 }
 
 /// Synchronous version of [`AsyncFd::bind`].
-///
-/// # Notes
-///
-/// This does not support direct descriptors, only regular file descriptors.
-pub fn sync_bind<A: SocketAddress>(fd: &AsyncFd, address: A) -> io::Result<()> {
-    if !matches!(fd.kind(), fd::Kind::File) {
-        return Err(io::ErrorKind::Unsupported.into());
-    }
-
+pub fn sync_bind<A: SocketAddress>(fd: impl AsFd, address: A) -> io::Result<()> {
     let address_storage = address.into_storage();
     let (ptr, length) = unsafe { A::as_ptr(&address_storage) };
-    syscall!(bind(fd.fd(), ptr.cast(), length))?;
+    syscall!(bind(fd.as_fd().as_raw_fd(), ptr.cast(), length))?;
     Ok(())
 }
 

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -7,6 +7,7 @@
 //! easier creation in non-async setup code) see [`sync_pipe`] and
 //! [`sync_pipe2`].
 
+use std::os::fd::{FromRawFd, OwnedFd};
 use std::{io, ptr};
 
 use crate::fd::{self, AsyncFd};
@@ -91,16 +92,17 @@ impl Pipe {
 /// Synchronous version of [`pipe`].
 ///
 /// See [`sync_pipe2`] for more.
-pub fn sync_pipe(sq: SubmissionQueue) -> io::Result<[AsyncFd; 2]> {
-    sync_pipe2(sq, PipeFlag(0))
+pub fn sync_pipe() -> io::Result<[OwnedFd; 2]> {
+    sync_pipe2(PipeFlag(0))
 }
 
 /// Synchronous version of [`pipe`].
 ///
 /// # Notes
 ///
-/// This does not support direct descriptors, only regular file descriptors.
-pub fn sync_pipe2(sq: SubmissionQueue, flags: PipeFlag) -> io::Result<[AsyncFd; 2]> {
+/// The returned fd is setup such that it can be converted into an [`AsyncFd`]
+/// without any further changes required to it.
+pub fn sync_pipe2(flags: PipeFlag) -> io::Result<[OwnedFd; 2]> {
     let mut fds = [-1, -1];
 
     let flags = flags.0.cast_signed() | libc::O_CLOEXEC;
@@ -132,12 +134,7 @@ pub fn sync_pipe2(sq: SubmissionQueue, flags: PipeFlag) -> io::Result<[AsyncFd; 
     syscall!(pipe(ptr::from_mut(&mut fds).cast()))?;
 
     // SAFETY: created the pipe fds above.
-    let fds = unsafe {
-        [
-            AsyncFd::from_raw(fds[0], fd::Kind::File, sq.clone()),
-            AsyncFd::from_raw(fds[1], fd::Kind::File, sq),
-        ]
-    };
+    let owned_fds = unsafe { [OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])] };
 
     // OS that don't support pipe2, we set NONBLOCK and CLOEXEC after opening.
     #[cfg(any(
@@ -148,12 +145,12 @@ pub fn sync_pipe2(sq: SubmissionQueue, flags: PipeFlag) -> io::Result<[AsyncFd; 
         target_os = "watchos",
     ))]
     {
-        syscall!(fcntl(fds[0].fd(), libc::F_SETFL, libc::O_NONBLOCK))?;
-        syscall!(fcntl(fds[0].fd(), libc::F_SETFD, libc::FD_CLOEXEC))?;
-        syscall!(fcntl(fds[1].fd(), libc::F_SETFL, libc::O_NONBLOCK))?;
-        syscall!(fcntl(fds[1].fd(), libc::F_SETFD, libc::FD_CLOEXEC))?;
+        syscall!(fcntl(fds[0], libc::F_SETFL, libc::O_NONBLOCK))?;
+        syscall!(fcntl(fds[0], libc::F_SETFD, libc::FD_CLOEXEC))?;
+        syscall!(fcntl(fds[1], libc::F_SETFL, libc::O_NONBLOCK))?;
+        syscall!(fcntl(fds[1], libc::F_SETFD, libc::FD_CLOEXEC))?;
         let _ = flags;
     }
 
-    Ok(fds)
+    Ok(owned_fds)
 }

--- a/tests/functional/net.rs
+++ b/tests/functional/net.rs
@@ -51,8 +51,8 @@ fn sync_socket_listener() {
     );
 
     sync_bind(&listener, address).unwrap();
-    let listener = AsyncFd::new(listener, sq);
     sync_listen(&listener, 1).unwrap();
+    let listener = AsyncFd::new(listener, sq);
     let local_addr = waker.block_on(listener.local_addr()).unwrap();
 
     // Accept a connection.

--- a/tests/functional/net.rs
+++ b/tests/functional/net.rs
@@ -10,7 +10,8 @@ use a10::net::socket;
 use a10::net::{
     Accept, Bind, Connect, Domain, MultishotAccept, MultishotRecv, NoAddress, Protocol, Recv,
     RecvN, RecvNVectored, Send, SendAll, SendAllVectored, SendTo, Socket, SocketName, Type, option,
-    sync_bind, sync_listen, sync_set_socket_option, sync_socket, sync_socket_option,
+    sync_bind, sync_listen, sync_local_addr, sync_set_socket_option, sync_socket,
+    sync_socket_option,
 };
 use a10::{AsyncFd, Extract, SubmissionQueue};
 
@@ -52,8 +53,8 @@ fn sync_socket_listener() {
 
     sync_bind(&listener, address).unwrap();
     sync_listen(&listener, 1).unwrap();
+    let local_addr = sync_local_addr(&listener).unwrap();
     let listener = AsyncFd::new(listener, sq);
-    let local_addr = waker.block_on(listener.local_addr()).unwrap();
 
     // Accept a connection.
     let mut stream = TcpStream::connect(local_addr).unwrap();

--- a/tests/functional/net.rs
+++ b/tests/functional/net.rs
@@ -43,7 +43,6 @@ fn sync_socket_listener() {
     let address: SocketAddr = ([127, 0, 0, 1], 0).into();
     let domain = Domain::for_address(&address);
     let listener = sync_socket(domain, Type::STREAM, Some(Protocol::TCP)).unwrap();
-    let listener = AsyncFd::new(listener, sq);
 
     sync_set_socket_option::<option::ReuseAddress>(&listener, true).unwrap();
     assert_eq!(
@@ -51,6 +50,7 @@ fn sync_socket_listener() {
         true,
     );
 
+    let listener = AsyncFd::new(listener, sq);
     sync_bind(&listener, address).unwrap();
     sync_listen(&listener, 1).unwrap();
     let local_addr = waker.block_on(listener.local_addr()).unwrap();

--- a/tests/functional/net.rs
+++ b/tests/functional/net.rs
@@ -12,7 +12,7 @@ use a10::net::{
     RecvN, RecvNVectored, Send, SendAll, SendAllVectored, SendTo, Socket, SocketName, Type, option,
     sync_bind, sync_listen, sync_set_socket_option, sync_socket, sync_socket_option,
 };
-use a10::{Extract, SubmissionQueue};
+use a10::{AsyncFd, Extract, SubmissionQueue};
 
 use crate::util::{
     BadBuf, BadBufSlice, BadReadBuf, BadReadBufSlice, Waker, bind_and_listen_ipv4, bind_ipv4,
@@ -42,7 +42,8 @@ fn sync_socket_listener() {
 
     let address: SocketAddr = ([127, 0, 0, 1], 0).into();
     let domain = Domain::for_address(&address);
-    let listener = sync_socket(sq, domain, Type::STREAM, Some(Protocol::TCP)).unwrap();
+    let listener = sync_socket(domain, Type::STREAM, Some(Protocol::TCP)).unwrap();
+    let listener = AsyncFd::new(listener, sq);
 
     sync_set_socket_option::<option::ReuseAddress>(&listener, true).unwrap();
     assert_eq!(

--- a/tests/functional/net.rs
+++ b/tests/functional/net.rs
@@ -50,8 +50,8 @@ fn sync_socket_listener() {
         true,
     );
 
-    let listener = AsyncFd::new(listener, sq);
     sync_bind(&listener, address).unwrap();
+    let listener = AsyncFd::new(listener, sq);
     sync_listen(&listener, 1).unwrap();
     let local_addr = waker.block_on(listener.local_addr()).unwrap();
 

--- a/tests/functional/pipe.rs
+++ b/tests/functional/pipe.rs
@@ -28,7 +28,11 @@ fn pipe_direct_descriptor() {
 #[test]
 fn sync_pipe_file_descriptor() {
     let sq = test_queue();
-    test_pipe(sync_pipe(sq).expect("failed to create pipe"))
+    test_pipe(
+        sync_pipe()
+            .map(|[r, s]| [AsyncFd::new(r, sq.clone()), AsyncFd::new(s, sq.clone())])
+            .expect("failed to create pipe"),
+    )
 }
 
 fn create_async(fd_kind: fd::Kind) -> [AsyncFd; 2] {


### PR DESCRIPTION
Since the sync functions are meant to be used in setup code using regular fds instead of AsyncFd makes it easier to use and more general. An AsyncFd can easily be created by using `AsyncFd::new(fd, sq)`.