### PR TITLE
Improve usage of test Ring

### DIFF
--- a/src/fd.rs
+++ b/src/fd.rs
@@ -64,7 +64,7 @@ impl AsyncFd {
     ///
     /// `fd` is expected to be a regular file descriptor.
     pub fn new(fd: OwnedFd, sq: SubmissionQueue) -> AsyncFd {
-        // SAFETY: OwnedFd ensure that `fd` is valid.
+        // SAFETY: OwnedFd ensures that `fd` is valid.
         unsafe { AsyncFd::from_raw_fd(fd.into_raw_fd(), sq) }
     }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -282,7 +282,7 @@ impl AsyncFd {
         // We deconstruct `self` without dropping it to avoid closing the fd
         // twice.
         let this = ManuallyDrop::new(self);
-        // SAFETY: this is safe because we're ensure the pointers are valid and
+        // SAFETY: this is safe because we're ensured the pointers are valid and
         // not touching `this` after reading the fields.
         let fd = this.fd();
         let kind = this.kind();

--- a/src/io/read_buf.rs
+++ b/src/io/read_buf.rs
@@ -321,8 +321,8 @@ impl ReadBuf {
     /// This is automatically called in the `Drop` implementation.
     pub fn release(&mut self) {
         if let Some(ptr) = self.owned.take() {
-            // SAFETY: this is safe because we're taking the address ensure we
-            // can't call this method again.
+            // SAFETY: this is safe because we're taking the address to ensure
+            // we can't call this method again.
             unsafe { self.shared.release(ptr) }
         }
     }

--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -292,7 +292,7 @@ fn mmap(
 ) -> io::Result<ptr::NonNull<libc::c_void>> {
     let addr = match unsafe { libc::mmap(ptr::null_mut(), len, prot, flags, fd, offset) } {
         libc::MAP_FAILED => return Err(io::Error::last_os_error()),
-        // SAFETY: mmap ensure the pointer is not null.
+        // SAFETY: mmap ensures the pointer is not null.
         addr => unsafe { ptr::NonNull::new_unchecked(addr) },
     };
 

--- a/src/io_uring/op.rs
+++ b/src/io_uring/op.rs
@@ -145,7 +145,7 @@ impl<T, R, A> OpState for State<T, R, A> {
     }
 
     fn resources_mut(&mut self) -> Option<&mut Self::Resources> {
-        // SAFETY: when the operation hasn't started we're ensure that we have
+        // SAFETY: when the operation hasn't started we're ensured that we have
         // unique access to all the state date.
         let data = unsafe { self.data.as_ref() };
         if let Status::NotStarted = lock(&data.shared).status {
@@ -168,7 +168,7 @@ impl<T, R, A> OpState for State<T, R, A> {
     }
 
     fn args_mut(&mut self) -> Option<&mut Self::Args> {
-        // SAFETY: when the operation hasn't started we're ensure that we have
+        // SAFETY: when the operation hasn't started we're ensured that we have
         // unique access to all the state date.
         let data = unsafe { self.data.as_ref() };
         if let Status::NotStarted = lock(&data.shared).status {

--- a/src/io_uring/process.rs
+++ b/src/io_uring/process.rs
@@ -7,7 +7,7 @@ use crate::io_uring::op::{FdOp, Op, OpReturn};
 use crate::io_uring::{self, libc, sq};
 use crate::op::operation;
 use crate::process::{Signal, SignalSet, Signals, WaitInfo, WaitOn, WaitOption};
-use crate::{AsyncFd, SubmissionQueue, fd, syscall};
+use crate::{AsyncFd, SubmissionQueue, fd, msan, syscall};
 
 pub(crate) struct WaitIdOp;
 
@@ -124,7 +124,8 @@ impl FdOp for ReceiveSignalOp {
 
     fn map_ok(_: &AsyncFd, info: Self::Resources, (_, n): OpReturn) -> Self::Output {
         debug_assert!(n == size_of::<libc::signalfd_siginfo>() as u32);
-        // SAFETY: initialised the info above.
+        // SAFETY: kernel initialised the info for us.
+        msan::unpoison_region(ptr::from_ref(&info).cast(), n as usize);
         unsafe { info.assume_init() }
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -315,7 +315,7 @@ impl AsyncFd {
         &'fd self,
         mut buf: B,
     ) -> RecvFrom<'fd, B, A> {
-        // SAFETY: we're ensure that `iovec` doesn't outlive the `buf`fer.
+        // SAFETY: we're ensured that `iovec` doesn't outlive the `buf`fer.
         let iovec = unsafe { IoMutSlice::new(&mut buf) };
         let resources = (buf, MsgHeader::empty(), iovec, MaybeUninit::uninit());
         RecvFrom::new(self, resources, RecvFlag(0))

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -64,7 +64,7 @@ impl IoSlice {
     }
 
     pub(crate) const fn as_bytes(&self) -> &[u8] {
-        // SAFETY: on creation we've ensure that `iov_base` and `iov_len` are
+        // SAFETY: on creation we've ensured that `iov_base` and `iov_len` are
         // valid.
         unsafe { std::slice::from_raw_parts(self.0.iov_base.cast(), self.0.iov_len) }
     }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -54,7 +54,37 @@ fn test_ring<'a>() -> &'a (RwLock<Ring>, SubmissionQueue) {
     })
 }
 
-fn poll_test_ring(timeout: Option<Duration>) {
+fn poll_test_ring() {
+    let (lock, _) = test_ring();
+    let mut ring = match lock.try_write() {
+        Ok(guard) => guard,
+        Err(TryLockError::Poisoned(err)) => {
+            lock.clear_poison();
+            err.into_inner()
+        }
+        Err(TryLockError::WouldBlock) => {
+            // If we can't lock the ring it means another thread is currently
+            // polling, that is fine we wait until it unlock before we return.
+            let guard = match lock.read() {
+                Ok(guard) => guard,
+                Err(err) => {
+                    lock.clear_poison();
+                    err.into_inner()
+                }
+            };
+            drop(guard);
+            return;
+        }
+    };
+
+    if let Err(err) = ring.poll(None) {
+        drop(ring);
+        panic!("unexpected error polling: {err}");
+    }
+}
+
+/// Ensure all submissions are submitted to the kernel.
+pub(crate) fn ensure_submitted() {
     let (lock, sq) = test_ring();
     let mut ring = match lock.try_write() {
         Ok(guard) => guard,
@@ -63,21 +93,16 @@ fn poll_test_ring(timeout: Option<Duration>) {
             err.into_inner()
         }
         Err(TryLockError::WouldBlock) => {
+            // Wake the polling thread so that we submit the new operations.
             sq.wake();
             return;
         }
     };
 
-    if let Err(err) = ring.poll(timeout) {
+    if let Err(err) = ring.poll(Some(Duration::ZERO)) {
         drop(ring);
         panic!("unexpected error polling: {err}");
     }
-}
-
-/// Wake up the thread that polls the shared ring to ensure all submissions are
-/// actuall submitted to the kernel.
-pub(crate) fn ensure_submitted() {
-    poll_test_ring(Some(Duration::ZERO));
 }
 
 pub(crate) fn test_queue() -> SubmissionQueue {
@@ -156,13 +181,19 @@ impl Waker {
         let mut future = pin!(future.into_future());
         let task_waker = thread_waker::new(thread::current());
         let mut task_ctx = task::Context::from_waker(&task_waker);
+        if let Poll::Ready(output) = Future::poll(future.as_mut(), &mut task_ctx) {
+            task_waker.wake(); // Don't drop it as it will panic.
+            return output;
+        } else {
+            ensure_submitted();
+        }
         loop {
             match Future::poll(future.as_mut(), &mut task_ctx) {
                 Poll::Ready(res) => {
                     task_waker.wake(); // Don't drop it as it will panic.
                     return res;
                 }
-                Poll::Pending => poll_test_ring(None),
+                Poll::Pending => poll_test_ring(),
             }
         }
     }

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -42,3 +42,22 @@ race:a10::io_uring::op::State*new
 # No idea why this function is causing false positive as it's only using stack
 # memory.
 race:functional::util::raw_pipe
+
+# Another weird case, which I think is a false positive. Both the mmap and pipe2
+# functions/system calls only use stack memory, but somehow a data race is
+# detected.
+#
+# WARNING: ThreadSanitizer: data race (pid=555539)
+#   Read of size 8 at 0x72b000000140 by thread T227:
+#     #0 mmap <null> (functional-0dcdd2faa0241176+0x2d32fb) (BuildId: 39f64565ad8fcf78b360d3e161c8f5400bab0d13)
+#     #1 a10::io_uring::mmap /home/thomas/src/a10/src/io_uring/mod.rs:293:31 (functional-0dcdd2faa0241176+0x774cac) (BuildId: 39f64565ad8fcf78b360d3e161c8f5400bab0d13)
+#     #2 <a10::io_uring::Shared>::new /home/thomas/src/a10/src/io_uring/mod.rs:95:31 (functional-0dcdd2faa0241176+0x773752) (BuildId: 39f64565ad8fcf78b360d3e161c8f5400bab0d13)
+#     #3 <a10::config::Config>::build_sys /home/thomas/src/a10/src/io_uring/config.rs:274:22 (functional-0dcdd2faa0241176+0x790286) (BuildId: 39f64565ad8fcf78b360d3e161c8f5400bab0d13)
+#     #4 <a10::config::Config>::build /home/thomas/src/a10/src/config.rs:22:29 (functional-0dcdd2faa0241176+0x78f4e0) (BuildId: 39f64565ad8fcf78b360d3e161c8f5400bab0d13)
+#     #5 <a10::Ring>::new /home/thomas/src/a10/src/lib.rs:168:24 (functional-0dcdd2faa0241176+0x79821a) (BuildId: 39f64565ad8fcf78b360d3e161c8f5400bab0d13)
+#
+#   Previous write of size 8 at 0x72b000000140 by thread T214:
+#     #0 pipe2 <null> (functional-0dcdd2faa0241176+0x2a0aa9) (BuildId: 39f64565ad8fcf78b360d3e161c8f5400bab0d13)
+#     #1 a10::pipe::sync_pipe2 /home/thomas/src/a10/src/lib.rs:286:28 (functional-0dcdd2faa0241176+0x77a7cb) (BuildId: 39f64565ad8fcf78b360d3e161c8f5400bab0d13)
+#     #2 a10::pipe::sync_pipe /home/thomas/src/a10/src/pipe.rs:96:5 (functional-0dcdd2faa0241176+0x77aa97) (BuildId: 39f64565ad8fcf78b360d3e161c8f5400bab0d13)
+race:a10::pipe::sync_pipe2


### PR DESCRIPTION
Before all threads would busy loop until their operations complete. This fixes that by attempting to get the Ring lock and thus sleeping.