### PR TITLE
Handle unexpected completion events

### DIFF
--- a/src/io_uring/cq.rs
+++ b/src/io_uring/cq.rs
@@ -125,11 +125,10 @@ pub(super) const SINGLESHOT_TAG: usize = 0b00;
 pub(super) const MULTISHOT_TAG: usize = 0b01;
 pub(super) const TAG_MASK: usize = !MULTISHOT_TAG;
 
-/// User data set for completions that can be ignored. For example when we're
-/// only interested in waking the polling thread.
-const NO_PROCESS: usize = 0;
-
-pub(super) const WAKE_USER_DATA: u64 = NO_PROCESS as u64;
+pub(super) const NO_USER_DATA: u64 = 0;
+pub(super) const WAKE_USER_DATA: u64 = 1;
+pub(super) const CANCEL_USER_DATA: u64 = 2;
+pub(super) const CLOSE_USER_DATA: u64 = 3;
 
 impl Completion {
     /// Process the completion event.
@@ -144,12 +143,35 @@ impl Completion {
             return;
         }
 
-        let user_data = self.0.user_data as usize;
-        if user_data == NO_PROCESS {
-            return;
+        let user_data = self.0.user_data;
+        match user_data {
+            // No user data set, shouldn't happen.
+            NO_USER_DATA => {
+                log::warn!(completion:? = self; "unexpected completion");
+                return;
+            }
+            // Only need to wake up.
+            WAKE_USER_DATA => return,
+            // Operation was not found (ENOENT), likely already completed, or
+            // the operation was already completing (EALREADY). Either way we
+            // can ignore it as the kernel will complete the operation soon.
+            CANCEL_USER_DATA if self.0.res == -libc::ENOENT || self.0.res == -libc::EALREADY => {
+                return;
+            }
+            // Other cancelation errors we log.
+            CANCEL_USER_DATA => {
+                log::warn!(completion:? = self; "unexpected cancelation completion");
+                return;
+            }
+            // Unexpected closing error.
+            CLOSE_USER_DATA => {
+                log::warn!(completion:? = self; "failed to close fd");
+                return;
+            }
+            _ => { /* Process completion below. */ }
         }
 
-        let ptr: *const () = ptr::with_exposed_provenance(user_data);
+        let ptr: *const () = ptr::with_exposed_provenance(user_data as usize);
         let is_singleshot = ptr.addr() & MULTISHOT_TAG == 0;
         let ptr = ptr.map_addr(|addr| addr & TAG_MASK);
         let update = if is_singleshot {

--- a/src/io_uring/fd.rs
+++ b/src/io_uring/fd.rs
@@ -3,6 +3,7 @@ use std::os::fd::RawFd;
 use std::{io, ptr};
 
 use crate::fd::{self, AsyncFd, Kind};
+use crate::io_uring::cq::CLOSE_USER_DATA;
 use crate::io_uring::op::{FdOp, Op, OpReturn};
 use crate::io_uring::sq::{self, Submission};
 use crate::io_uring::{self, libc};
@@ -213,6 +214,7 @@ impl Drop for AsyncFd {
     fn drop(&mut self) {
         let res = self.sq.submissions().add(|submission| {
             io_uring::io::close_file_fd(self.fd(), self.kind(), submission);
+            submission.0.user_data = CLOSE_USER_DATA;
         });
         if let Ok(()) = res {
             return;

--- a/src/io_uring/fd.rs
+++ b/src/io_uring/fd.rs
@@ -215,6 +215,7 @@ impl Drop for AsyncFd {
         let res = self.sq.submissions().add(|submission| {
             io_uring::io::close_file_fd(self.fd(), self.kind(), submission);
             submission.0.user_data = CLOSE_USER_DATA;
+            submission.no_success_event();
         });
         if let Ok(()) = res {
             return;

--- a/src/io_uring/sq.rs
+++ b/src/io_uring/sq.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{self, Ordering};
 use std::time::Duration;
 use std::{fmt, io, ptr, task};
 
-use crate::io_uring::cq::{self, MULTISHOT_TAG, TAG_MASK};
+use crate::io_uring::cq::{self, CANCEL_USER_DATA, MULTISHOT_TAG, TAG_MASK, WAKE_USER_DATA};
 use crate::io_uring::{Shared, libc, load_kernel_shared};
 use crate::{asan, lock, syscall};
 
@@ -84,6 +84,7 @@ impl Submissions {
         self.add(|submission| {
             submission.0.opcode = libc::IORING_OP_ASYNC_CANCEL as u8;
             submission.0.__bindgen_anon_2 = libc::io_uring_sqe__bindgen_ty_2 { addr: user_data };
+            submission.0.user_data = CANCEL_USER_DATA;
             // We'll get a canceled completion event if we succeeded, which is
             // sufficient to cleanup the operation.
             submission.no_success_event();
@@ -107,6 +108,7 @@ impl Submissions {
             submission.0.__bindgen_anon_1 = libc::io_uring_sqe__bindgen_ty_1 {
                 off: cq::WAKE_USER_DATA,
             };
+            submission.0.user_data = WAKE_USER_DATA;
         };
 
         if self.shared.single_issuer {

--- a/src/io_uring/sq.rs
+++ b/src/io_uring/sq.rs
@@ -210,7 +210,7 @@ impl Submission {
     /// [`reset`]: Submission::reset
     #[cfg(debug_assertions)]
     const fn is_unchanged(&self) -> bool {
-        self.0.opcode == libc::IORING_OP_NOP as u8
+        self.0.opcode == libc::IORING_OP_NOP as u8 || self.0.user_data == 0
     }
 
     /// Don't attempt to do the operation non-blocking first, always execute it


### PR DESCRIPTION
Instead of silently ignoring them, log them with context info where possible.

Closes #290