### PR TITLE
Poll Ring before dropping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,17 @@ impl Ring {
     }
 }
 
+impl Drop for Ring {
+    fn drop(&mut self) {
+        // Poll the ring one last time to ensure that any asynchronous
+        // operations such as closing of fds or canceling of multishot
+        // operations is processed. This allows us to clean up resources.
+        if let Err(err) = self.poll(Some(Duration::ZERO)) {
+            log::warn!("error polling Ring before drop: {err}");
+        }
+    }
+}
+
 /// Queue to submit asynchronous operations to.
 ///
 /// This type doesn't have many public methods, but is used by all I/O types to


### PR DESCRIPTION
To process any pending completion events for things like asynchronously closing file descriptors or canceling multishot operations.