### PR TITLE
Cleanup and cancel pending operations on Drop of Ring

### DIFF
--- a/src/io_uring/cq.rs
+++ b/src/io_uring/cq.rs
@@ -1,7 +1,7 @@
 use std::os::fd::RawFd;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
-use std::{fmt, io, ptr};
+use std::{fmt, io, mem, ptr};
 
 use crate::io_uring::{Shared, libc, load_kernel_shared, mmap, munmap, op};
 use crate::{asan, debug_detail, lock};
@@ -96,6 +96,46 @@ impl Completions {
         unsafe { (&*self.entries_head.as_ptr()).store(head, Ordering::Release) };
 
         Ok(())
+    }
+
+    pub(crate) fn drop(&mut self, shared: &Shared) {
+        // Submit any pending operations, mainly aiming to submit clean up
+        // operations such as asynchronously closing fds, etc.
+        let mut flags = 0; // Only submit.
+        if shared.kernel_thread {
+            flags |= libc::IORING_ENTER_SQ_WAIT;
+        }
+        if let Err(err) = shared.enter(libc::c_uint::MAX, flags, Some(Duration::from_secs(1))) {
+            log::warn!("error flushing submissions: {err}");
+        }
+
+        // Hopefully at this point the clean up operations have been completed,
+        // but we're not guaranteed that. Cancel any remaining operations, as
+        // they'll never make progress once we drop the completions.
+        let cancel = libc::io_uring_sync_cancel_reg {
+            addr: 0, // Unused.
+            fd: -1,  // Unused.
+            flags: libc::IORING_ASYNC_CANCEL_ANY | libc::IORING_ASYNC_CANCEL_ALL,
+            timeout: libc::__kernel_timespec {
+                tv_sec: 1,
+                tv_nsec: 0,
+            },
+            ..unsafe { mem::zeroed() }
+        };
+        let cancel_ptr = ptr::from_ref(&cancel).cast();
+        if let Err(err) = shared.register(libc::IORING_REGISTER_SYNC_CANCEL, cancel_ptr, 1) {
+            log::warn!("error cancelling operations: {err}");
+        }
+
+        // Process the remaining completions events that are ready.
+        // NOTE: we explitly enter here to ensure we get the latests completions
+        // from the kernel, poll doesn't guarantee that.
+        if let Err(err) = shared.enter(1, libc::IORING_ENTER_GETEVENTS, Some(Duration::ZERO)) {
+            log::warn!("error getting last completions: {err}");
+        }
+        if let Err(err) = self.poll(shared, Some(Duration::ZERO)) {
+            log::warn!("error processing last completions: {err}");
+        }
     }
 }
 

--- a/src/kqueue/cq.rs
+++ b/src/kqueue/cq.rs
@@ -54,4 +54,13 @@ impl Completions {
         shared.reuse_change_list(changes);
         Ok(())
     }
+
+    pub(crate) fn drop(&mut self, shared: &Shared) {
+        // Poll one last time to finish of any asynchronous operations such as
+        // canceling multishot operations, allowing for resources to be cleaned
+        // up.
+        if let Err(err) = self.poll(shared, Some(Duration::ZERO)) {
+            log::warn!("error processing last completions: {err}");
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,12 +212,7 @@ impl Ring {
 
 impl Drop for Ring {
     fn drop(&mut self) {
-        // Poll the ring one last time to ensure that any asynchronous
-        // operations such as closing of fds or canceling of multishot
-        // operations is processed. This allows us to clean up resources.
-        if let Err(err) = self.poll(Some(Duration::ZERO)) {
-            log::warn!("error polling Ring before drop: {err}");
-        }
+        self.cq.drop(self.sq.shared());
     }
 }
 

--- a/tests/functional/net.rs
+++ b/tests/functional/net.rs
@@ -273,17 +273,9 @@ fn multishot_accept_drop_accept_before_close_leak_test() {
     let sq = ring.sq();
 
     let listener = block_on(&mut ring, tcp_ipv4_socket(sq));
-    {
-        let mut accept = listener.multishot_accept();
-        start_iter(Pin::new(&mut accept));
-        drop(accept);
-    }
-
-    // We need this poll to ensure we process the asynchronous cancelation of
-    // the multishot accept (done on drop).
-    ring.poll(None).unwrap();
-
-    drop(listener);
+    let mut accept = listener.multishot_accept();
+    start_iter(Pin::new(&mut accept));
+    drop(accept);
 }
 
 #[test]
@@ -295,17 +287,11 @@ fn multishot_accept_drop_accept_leak_test() {
     let mut ring = a10::Ring::new().unwrap();
     let sq = ring.sq();
 
-    {
-        let listener = block_on(&mut ring, tcp_ipv4_socket(sq));
-        let mut accept = listener.multishot_accept();
-        start_iter(Pin::new(&mut accept));
-        drop(accept);
-        drop(listener);
-    }
-
-    // We need this poll to ensure we process the asynchronous cancelation of
-    // the multishot accept (done on drop).
-    ring.poll(None).unwrap();
+    let listener = block_on(&mut ring, tcp_ipv4_socket(sq));
+    let mut accept = listener.multishot_accept();
+    start_iter(Pin::new(&mut accept));
+    drop(accept);
+    drop(listener);
 }
 
 #[test]

--- a/tests/functional/ring.rs
+++ b/tests/functional/ring.rs
@@ -165,10 +165,6 @@ fn submission_queue_full_is_handled_internally() {
 
         ring.poll(None).unwrap();
     }
-
-    // NOTE: this is here to deallocate the resources in the Future that was
-    // stalled.
-    ring.poll(Some(Duration::ZERO)).unwrap();
 }
 
 #[test]
@@ -210,7 +206,7 @@ fn pollable() {
 #[test]
 fn pollable_drop_leak_test() {
     init();
-    let mut main_ring = Ring::new().unwrap();
+    let main_ring = Ring::new().unwrap();
     let other_ring = Ring::new().unwrap();
 
     {
@@ -218,10 +214,6 @@ fn pollable_drop_leak_test() {
         start_iter(Pin::new(&mut ring_pollable));
         drop(ring_pollable);
     }
-
-    // We need this poll to ensure we process the asynchronous cancelation of
-    // the pollable iter (done on drop).
-    main_ring.poll(None).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This (hopefully) ensures that any asynchronous cleanup operations such as closing fds and cancelling dropping multishot operations are completed before the Ring is dropped. Any long running operations that haven't been completed should be cancel. For both, the completed and cancelled operations, processing of the completions should cleanup any resources (mainly the state of the operations).

However, since io_uring is all asynchronous I don't think that any of this is guaranteed.

Closes #293
Closes #294